### PR TITLE
Fix invalid scope

### DIFF
--- a/themes/light.json
+++ b/themes/light.json
@@ -282,9 +282,8 @@
     {
       "scope": "invalid.illegal",
       "settings": {
-        "fontStyle": "italic underline",
-        "background": "#b31d28",
-        "foreground": "#fafbfc"
+        "fontStyle": "italic",
+        "foreground": "#b31d28"
       }
     },
     {

--- a/themes/light.json
+++ b/themes/light.json
@@ -268,14 +268,14 @@
     {
       "scope": "invalid.broken",
       "settings": {
-        "fontStyle": "bold italic underline",
+        "fontStyle": "italic",
         "foreground": "#b31d28"
       }
     },
     {
       "scope": "invalid.deprecated",
       "settings": {
-        "fontStyle": "bold italic underline",
+        "fontStyle": "italic",
         "foreground": "#b31d28"
       }
     },
@@ -289,7 +289,7 @@
     {
       "scope": "invalid.unimplemented",
       "settings": {
-        "fontStyle": "bold italic underline",
+        "fontStyle": "italic",
         "foreground": "#b31d28"
       }
     },

--- a/themes/light.json
+++ b/themes/light.json
@@ -287,19 +287,19 @@
       }
     },
     {
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "fontStyle": "bold italic underline",
+        "foreground": "#b31d28"
+      }
+    },
+    {
       "scope": "carriage-return",
       "settings": {
         "fontStyle": "italic underline",
         "background": "#d73a49",
         "foreground": "#fafbfc",
         "content": "^M"
-      }
-    },
-    {
-      "scope": "invalid.unimplemented",
-      "settings": {
-        "fontStyle": "bold italic underline",
-        "foreground": "#b31d28"
       }
     },
     {


### PR DESCRIPTION
This fixes the `invalid.illegal` scope. For some reason the red background is not shown, making the white text unreadable.

Before | After
--- | ---
![Screen Shot 2020-04-20 at 11 59 42 AM](https://user-images.githubusercontent.com/378023/79710415-dcbf0900-82ff-11ea-8142-408387eeac65.png) | ![Screen Shot 2020-04-20 at 12 00 33 PM](https://user-images.githubusercontent.com/378023/79710417-de88cc80-82ff-11ea-93b5-4cbf8f3a535f.png)

---

Fixes https://github.com/primer/github-vscode-theme/issues/1