### PR TITLE
Add status bar colors

### DIFF
--- a/themes/light.json
+++ b/themes/light.json
@@ -76,6 +76,7 @@
     "statusBar.foreground": "#586069",
     "statusBar.background": "#fff",
     "statusBar.border": "#e1e4e8",
+    "statusBar.noFolderBackground": "#fff",
 
     "editorGroupHeader.tabsBackground": "#f6f8fa",
     "editorGroupHeader.tabsBorder": "#e1e4e8",

--- a/themes/light.json
+++ b/themes/light.json
@@ -77,6 +77,8 @@
     "statusBar.background": "#fff",
     "statusBar.border": "#e1e4e8",
     "statusBar.noFolderBackground": "#fff",
+    "statusBar.debuggingBackground": "#f9826c",
+    "statusBar.debuggingForeground": "#ffffff",
 
     "editorGroupHeader.tabsBackground": "#f6f8fa",
     "editorGroupHeader.tabsBorder": "#e1e4e8",

--- a/themes/light.json
+++ b/themes/light.json
@@ -78,7 +78,7 @@
     "statusBar.border": "#e1e4e8",
     "statusBar.noFolderBackground": "#fff",
     "statusBar.debuggingBackground": "#f9826c",
-    "statusBar.debuggingForeground": "#ffffff",
+    "statusBar.debuggingForeground": "#fff",
 
     "editorGroupHeader.tabsBackground": "#f6f8fa",
     "editorGroupHeader.tabsBorder": "#e1e4e8",


### PR DESCRIPTION
Fixes #5 

I updated the theme to use the same status bar colors when in opening a new window/no workspace:

![image](https://user-images.githubusercontent.com/35271042/80152674-fb780680-8570-11ea-822f-4baed6539843.png)

Also updated the status bar colors for when you are debugging, since there were none defined:

![image](https://user-images.githubusercontent.com/35271042/80152736-1480b780-8571-11ea-807e-471b0ae69ef7.png)
