### PR TITLE
Custom list.activeSelection

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -74,7 +74,7 @@ function getTheme({ style, name }) {
       "list.activeSelectionForeground": primer.gray[9],
       "list.hoverBackground": pick({ light: "#ebf0f4", dark: primer.gray[0] }),
       "list.inactiveSelectionBackground": pick({ light: "#e8eaed", dark: "#282e34" }),
-      "list.activeSelectionBackground": pick({ light: "#e2e5e9", dark: primer.gray[1] }),
+      "list.activeSelectionBackground": pick({ light: "#e2e5e9", dark: "#39414a" }),
       "list.inactiveFocusBackground": pick({ light: primer.blue[1], dark: "#1d2d3e" }),
       "list.focusBackground": pick({ light: "#cce5ff", dark: primer.blue[2] }),
 

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -52,7 +52,7 @@
     "list.activeSelectionForeground": "#fafbfc",
     "list.hoverBackground": "#24292e",
     "list.inactiveSelectionBackground": "#282e34",
-    "list.activeSelectionBackground": "#2f363d",
+    "list.activeSelectionBackground": "#39414a",
     "list.inactiveFocusBackground": "#1d2d3e",
     "list.focusBackground": "#044289",
     "tree.indentGuidesStroke": "#2f363d",


### PR DESCRIPTION
This makes the `list.activeSelection` a bit lighter:

Before | After
--- | ---
![Screen Shot 2020-05-07 at 8 03 27 PM](https://user-images.githubusercontent.com/378023/81287510-da99d000-909d-11ea-8683-891513c4a11e.png) | ![Screen Shot 2020-05-07 at 8 02 50 PM](https://user-images.githubusercontent.com/378023/81287506-d968a300-909d-11ea-969c-958c6aec87f4.png)

It should fix #11 
