### PR TITLE
Decrease whitespace characters color contrast

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -121,7 +121,7 @@ function getTheme({ style, name }) {
       "editorLineNumber.activeForeground": primer.gray[9],
       "editorIndentGuide.background": pick({ light: "#eff2f6", dark: primer.gray[1] }),
       "editorIndentGuide.activeBackground": pick({ light: "#d7dbe0", dark: primer.gray[2] }),
-      "editorWhitespace.foreground": pick({ light: primer.gray[4], dark: primer.gray[4] }),
+      "editorWhitespace.foreground": pick({ light: primer.gray[3], dark: primer.gray[2] }),
       "editorCursor.foreground": primer.blue[7],
       "editor.inactiveSelectionBackground": pick({ light: "#0366d611", dark: "#79b8ff11" }),
       "editor.selectionBackground": pick({ light: "#0366d625", dark: "#2188ff33" }),

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -93,7 +93,7 @@
     "editorLineNumber.activeForeground": "#fafbfc",
     "editorIndentGuide.background": "#2f363d",
     "editorIndentGuide.activeBackground": "#444d56",
-    "editorWhitespace.foreground": "#6a737d",
+    "editorWhitespace.foreground": "#444d56",
     "editorCursor.foreground": "#c8e1ff",
     "editor.inactiveSelectionBackground": "#79b8ff11",
     "editor.selectionBackground": "#2188ff33",

--- a/themes/light.json
+++ b/themes/light.json
@@ -93,7 +93,7 @@
     "editorLineNumber.activeForeground": "#24292e",
     "editorIndentGuide.background": "#eff2f6",
     "editorIndentGuide.activeBackground": "#d7dbe0",
-    "editorWhitespace.foreground": "#959da5",
+    "editorWhitespace.foreground": "#d1d5da",
     "editorCursor.foreground": "#044289",
     "editor.inactiveSelectionBackground": "#0366d611",
     "editor.selectionBackground": "#0366d625",


### PR DESCRIPTION
I decreased the whitespace characters contrast. They were bit too visible for users who render them. Used colors from the Primer's color system.

**Screenshots of the new colors:**

<img width="1041" alt="vscode-gh-theme-pr" src="https://user-images.githubusercontent.com/927409/81378576-31d88880-9110-11ea-8513-84fab7141ff2.png">
