### PR TITLE
Lighten the whitespace characters to $gray-300

### DIFF
--- a/themes/light.json
+++ b/themes/light.json
@@ -93,7 +93,7 @@
     "editorLineNumber.activeForeground": "#24292e",
     "editorIndentGuide.background": "#eff2f6",
     "editorIndentGuide.activeBackground": "#d7dbe0",
-    "editorWhitespace.foreground": "#959da5",
+    "editorWhitespace.foreground": "#d1d5da",
     "editorCursor.foreground": "#044289",
     "editor.inactiveSelectionBackground": "#0366d611",
     "editor.selectionBackground": "#0366d625",


### PR DESCRIPTION
The `$gray-400` is probably better for accessibility contrast, but it causes the whitespace to clutter the text making it hard to read.

#### Before
<img width="786" alt="Screenshot 2020-05-08 13 51 30" src="https://user-images.githubusercontent.com/2694/81434181-c4d6ea00-9133-11ea-8345-36d3cfc16b23.png">

#### After
<img width="795" alt="Screenshot 2020-05-08 13 52 06" src="https://user-images.githubusercontent.com/2694/81434190-ca343480-9133-11ea-807e-2029323badae.png">
