### PR TITLE
Darker strings

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -233,7 +233,7 @@ function getTheme({ style, name }) {
           "string punctuation.section.embedded source",
         ],
         settings: {
-          foreground: primer.blue[8],
+          foreground: pick({ light: primer.blue[8], dark: "#9ecbff" }),
         },
       },
       {

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -209,7 +209,7 @@
         "string punctuation.section.embedded source"
       ],
       "settings": {
-        "foreground": "#dbedff"
+        "foreground": "#9ecbff"
       }
     },
     {


### PR DESCRIPTION
This is a "quick fix" https://github.com/primer/github-vscode-theme/issues/19 and makes strings a bit darker:

Before | After
--- | ---
<img width="278" alt="CleanShot 2020-05-12 at 19 04 15@2x" src="https://user-images.githubusercontent.com/378023/81671001-69826000-9483-11ea-96e1-607f17ea50c3.png"> | <img width="282" alt="CleanShot 2020-05-12 at 18 51 50@2x" src="https://user-images.githubusercontent.com/378023/81669806-b107ec80-9481-11ea-8640-688ec3b8e75d.png">
