### PR TITLE
Enable semantic highlighting

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -168,6 +168,7 @@ function getTheme({ style, name }) {
       "welcomePage.buttonBackground": primer.gray[1],
       "welcomePage.buttonHoverBackground": primer.gray[2],
     },
+    semanticHighlighting: true,
     tokenColors: [
       {
         scope: ["comment", "punctuation.definition.comment", "string.comment"],

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -134,6 +134,7 @@
     "welcomePage.buttonBackground": "#2f363d",
     "welcomePage.buttonHoverBackground": "#444d56"
   },
+  "semanticHighlighting": true,
   "tokenColors": [
     {
       "scope": [

--- a/themes/light.json
+++ b/themes/light.json
@@ -134,6 +134,7 @@
     "welcomePage.buttonBackground": "#f6f8fa",
     "welcomePage.buttonHoverBackground": "#e1e4e8"
   },
+  "semanticHighlighting": true,
   "tokenColors": [
     {
       "scope": [


### PR DESCRIPTION
This enables [semantic highlighting](https://code.visualstudio.com/docs/getstarted/themes#_semantic-highlighting). I haven't looked into the details, but I can see a difference with this [sample TS code](https://github.com/atom/language-examples/blob/b0aa83840d93ca10ab093e121bcfdfa1e5b54163/languages/typescript.ts#L17-L26):

Before | After
--- | ---
![CleanShot 2020-05-13 at 16 51 11](https://user-images.githubusercontent.com/378023/81786371-829a1800-953a-11ea-8023-cbdec046b1a4.png) | ![CleanShot 2020-05-13 at 16 50 26](https://user-images.githubusercontent.com/378023/81786379-862d9f00-953a-11ea-8eca-c03818babd14.png)

![image](https://user-images.githubusercontent.com/378023/81786658-f0deda80-953a-11ea-8a2c-4632f444e347.png)

I guess semantically it's not a `variable` but a `property` that falls back to the `variable.other` color? 🤔 Anyways, we can make further tweaks if needed.

---

Closes https://github.com/primer/github-vscode-theme/issues/25