### PR TITLE
Update debug foreground color for dark theme

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -99,7 +99,7 @@ function getTheme({ style, name }) {
       "statusBar.border": pick({ light: primer.gray[2], dark: primer.white }),
       "statusBar.noFolderBackground": pick({ light: primer.white, dark: primer.gray[0] }),
       "statusBar.debuggingBackground": auto("#f9826c"),
-      "statusBar.debuggingForeground": primer.white,
+      "statusBar.debuggingForeground": pick({ light: primer.white, dark: primer.black }),
 
       "editorGroupHeader.tabsBackground": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "editorGroupHeader.tabsBorder": pick({ light: primer.gray[2], dark: primer.white }),

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -73,7 +73,7 @@
     "statusBar.border": "#1b1f23",
     "statusBar.noFolderBackground": "#24292e",
     "statusBar.debuggingBackground": "#931c06",
-    "statusBar.debuggingForeground": "#1b1f23",
+    "statusBar.debuggingForeground": "#fff",
     "editorGroupHeader.tabsBackground": "#1f2428",
     "editorGroupHeader.tabsBorder": "#1b1f23",
     "editorGroup.border": "#1b1f23",


### PR DESCRIPTION
The dark theme debug foreground color is dark text on a dark background, which makes it hard to read. This updates the foreground color to be white.

## Before
![image](https://user-images.githubusercontent.com/35271042/81891475-5e036780-955d-11ea-8306-78044cf7498b.png)

## After
![image](https://user-images.githubusercontent.com/35271042/81891481-6065c180-955d-11ea-983f-22189c76e952.png)

<hr>

Closes #34