### PR TITLE
Increase contrast for list.hoverBackground

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -72,7 +72,7 @@ function getTheme({ style, name }) {
       "list.hoverForeground": primer.gray[9],
       "list.inactiveSelectionForeground": primer.gray[9],
       "list.activeSelectionForeground": primer.gray[9],
-      "list.hoverBackground": pick({ light: "#ebf0f4", dark: primer.gray[0] }),
+      "list.hoverBackground": pick({ light: "#ebf0f4", dark: "#282e34" }),
       "list.inactiveSelectionBackground": pick({ light: "#e8eaed", dark: "#282e34" }),
       "list.activeSelectionBackground": pick({ light: "#e2e5e9", dark: "#39414a" }),
       "list.inactiveFocusBackground": pick({ light: primer.blue[1], dark: "#1d2d3e" }),

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -50,7 +50,7 @@
     "list.hoverForeground": "#fafbfc",
     "list.inactiveSelectionForeground": "#fafbfc",
     "list.activeSelectionForeground": "#fafbfc",
-    "list.hoverBackground": "#24292e",
+    "list.hoverBackground": "#282e34",
     "list.inactiveSelectionBackground": "#282e34",
     "list.activeSelectionBackground": "#39414a",
     "list.inactiveFocusBackground": "#1d2d3e",


### PR DESCRIPTION
This fixes the invisible hovered command palette item for the dark theme.

![image](https://user-images.githubusercontent.com/378023/82053026-9dfe5200-96f7-11ea-860b-e44af84f8f48.png)

---

Closes #14