### PR TITLE
Brighter gray for sidebar, sidebar header and terminal foregrounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "github-vscode-theme",
-	"version": "1.1.3",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "github-vscode-theme",
 	"displayName": "GitHub Theme",
 	"description": "GitHub theme for VS Code",
-	"version": "1.1.3",
+	"version": "1.2.0",
 	"preview": true,
 	"publisher": "GitHub",
 	"license": "MIT",

--- a/src/theme.js
+++ b/src/theme.js
@@ -65,11 +65,11 @@ function getTheme({ style, name }) {
       "activityBar.activeBorder": "#f9826c",
       "activityBar.border": pick({ light: primer.gray[2], dark: primer.white }),
 
-      "sideBar.foreground": primer.gray[6],
+      "sideBar.foreground": primer.gray[4],
       "sideBar.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "sideBar.border": pick({ light: primer.gray[2], dark: primer.white }),
       "sideBarTitle.foreground": workbenchForeground,
-      "sideBarSectionHeader.foreground": workbenchForeground,
+      "sideBarSectionHeader.foreground": primer.gray[4],
       "sideBarSectionHeader.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "sideBarSectionHeader.border": pick({ light: primer.gray[2], dark: primer.white }),
 
@@ -171,7 +171,7 @@ function getTheme({ style, name }) {
       "panelTitle.inactiveForeground": primer.gray[5],
       "panelInput.border": pick({ light: primer.gray[2], dark: primer.gray[1] }),
 
-      "terminal.foreground": primer.gray[6],
+      "terminal.foreground": primer.gray[4],
 
       "gitDecoration.addedResourceForeground": primer.green[5],
       "gitDecoration.modifiedResourceForeground": primer.blue[6],

--- a/src/theme.js
+++ b/src/theme.js
@@ -65,11 +65,11 @@ function getTheme({ style, name }) {
       "activityBar.activeBorder": "#f9826c",
       "activityBar.border": pick({ light: primer.gray[2], dark: primer.white }),
 
-      "sideBar.foreground": primer.gray[4],
+      "sideBar.foreground": primer.gray[5],
       "sideBar.background": pick({ light: primer.white, dark: primer.gray[0] }),
       "sideBar.border": pick({ light: primer.gray[2], dark: primer.white }),
       "sideBarTitle.foreground": workbenchForeground,
-      "sideBarSectionHeader.foreground": primer.gray[4],
+      "sideBarSectionHeader.foreground": primer.gray[5],
       "sideBarSectionHeader.background": pick({ light: primer.white, dark: primer.gray[0] }),
       "sideBarSectionHeader.border": pick({ light: primer.gray[2], dark: primer.white }),
 
@@ -171,7 +171,7 @@ function getTheme({ style, name }) {
       "panelTitle.inactiveForeground": primer.gray[5],
       "panelInput.border": pick({ light: primer.gray[2], dark: primer.gray[1] }),
 
-      "terminal.foreground": primer.gray[4],
+      "terminal.foreground": primer.gray[5],
 
       "gitDecoration.addedResourceForeground": primer.green[5],
       "gitDecoration.modifiedResourceForeground": primer.blue[6],

--- a/src/theme.js
+++ b/src/theme.js
@@ -47,7 +47,7 @@ function getTheme({ style, name }) {
       "input.placeholderForeground": pick({ light: primer.gray[4], dark: primer.gray[5] }),
 
       "badge.foreground": pick({ light: primer.blue[6], dark: primer.blue[7] }),
-      "badge.background": pick({ light: primer.blue[1], dark: primer.blue[2] }),
+      "badge.background": pick({ light: primer.blue[4], dark: primer.blue[4] }),
 
       "progressBar.background": primer.blue[4],
 
@@ -61,7 +61,7 @@ function getTheme({ style, name }) {
       "activityBar.inactiveForeground": primer.gray[4],
       "activityBar.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "activityBarBadge.foreground": pick({ light: primer.white, dark: primer.black }),
-      "activityBarBadge.background": pick({ light: primer.blue[4], dark: primer.blue[4] }),
+      "activityBarBadge.background": pick({ light: primer.blue[1], dark: primer.blue[2] }),
       "activityBar.activeBorder": "#f9826c",
       "activityBar.border": pick({ light: primer.gray[2], dark: primer.white }),
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -59,18 +59,18 @@ function getTheme({ style, name }) {
 
       "activityBar.foreground": workbenchForeground,
       "activityBar.inactiveForeground": primer.gray[4],
-      "activityBar.background": pick({ light: primer.white, dark: primer.gray[0] }),
+      "activityBar.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "activityBarBadge.foreground": pick({ light: primer.white, dark: primer.black }),
       "activityBarBadge.background": pick({ light: primer.blue[4], dark: primer.blue[4] }),
       "activityBar.activeBorder": "#f9826c",
       "activityBar.border": pick({ light: primer.gray[2], dark: primer.white }),
 
       "sideBar.foreground": primer.gray[4],
-      "sideBar.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "sideBar.background": pick({ light: primer.white, dark: primer.gray[0] }),
       "sideBar.border": pick({ light: primer.gray[2], dark: primer.white }),
       "sideBarTitle.foreground": workbenchForeground,
       "sideBarSectionHeader.foreground": primer.gray[4],
-      "sideBarSectionHeader.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "sideBarSectionHeader.background": pick({ light: primer.white, dark: primer.gray[0] }),
       "sideBarSectionHeader.border": pick({ light: primer.gray[2], dark: primer.white }),
 
       "list.hoverForeground": workbenchForeground,
@@ -99,13 +99,13 @@ function getTheme({ style, name }) {
       "quickInput.foreground": workbenchForeground,
 
       "statusBar.foreground": primer.gray[6],
-      "statusBar.background": pick({ light: primer.white, dark: primer.gray[0] }),
+      "statusBar.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "statusBar.border": pick({ light: primer.gray[2], dark: primer.white }),
       "statusBar.noFolderBackground": pick({ light: primer.white, dark: primer.gray[0] }),
       "statusBar.debuggingBackground": auto("#f9826c"),
       "statusBar.debuggingForeground": pick({ light: primer.white, dark: primer.black }),
 
-      "editorGroupHeader.tabsBackground": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "editorGroupHeader.tabsBackground": pick({ light: primer.white, dark: primer.gray[0] }),
       "editorGroupHeader.tabsBorder": pick({ light: primer.gray[2], dark: primer.white }),
       "editorGroup.border": pick({ light: primer.gray[2], dark: primer.white }),
 
@@ -127,7 +127,7 @@ function getTheme({ style, name }) {
       "breadcrumbPicker.background": pick({ light: primer.gray[0], dark: "#2b3036" }),
 
       "editor.foreground": editorForeground,
-      "editor.background": pick({ light: primer.white, dark: primer.gray[0] }),
+      "editor.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "editorWidget.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "editor.foldBackground": pick({ light: primer.gray[0], dark: "#282e33" }),
       "editor.lineHighlightBackground": pick({ light: primer.gray[1], dark: "#2b3036" }),
@@ -164,7 +164,7 @@ function getTheme({ style, name }) {
       "scrollbarSlider.activeBackground": pick({ light: "#959da588", dark: "#6a737d88" }),
       "editorOverviewRuler.border": primer.white,
 
-      "panel.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "panel.background": pick({ light: primer.white, dark: primer.gray[0] }),
       "panel.border": pick({ light: primer.gray[2], dark: primer.white }),
       "panelTitle.activeBorder": "#f9826c",
       "panelTitle.activeForeground": workbenchForeground,


### PR DESCRIPTION
I added a brighter gray (primer.gray[5]) for sidebar, sidebar header and terminal foregrounds to match breadcrumbs.