### PR TITLE
Add statusbar prominent background

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -104,6 +104,7 @@ function getTheme({ style, name }) {
       "statusBar.noFolderBackground": pick({ light: primer.white, dark: primer.gray[0] }),
       "statusBar.debuggingBackground": auto("#f9826c"),
       "statusBar.debuggingForeground": pick({ light: primer.white, dark: primer.black }),
+      "statusBarItem.prominentBackground": pick({ light: "#e8eaed", dark: "#282e34" }),
 
       "editorGroupHeader.tabsBackground": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "editorGroupHeader.tabsBorder": pick({ light: primer.gray[2], dark: primer.white }),


### PR DESCRIPTION
This adds support for `statusBarItem.prominentBackground`.

 ```json
"statusBarItem.prominentBackground": pick({ light: "#e8eaed", dark: "#282e34" }),
```

![Screen Shot 2020-09-04 at 14 38 19](https://user-images.githubusercontent.com/378023/92203738-def3bf80-eebc-11ea-99f4-6980154c5eb8.png)

---

- Superseeds and closes #77
- /cc @phgmacedo