### PR TITLE
sync dark colors with new official GitHub dark theme

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -54,7 +54,7 @@ function getTheme({ style, name }) {
       "titleBar.activeForeground": workbenchForeground,
       "titleBar.activeBackground": pick({ light: primer.white, dark: primer.gray[0] }),
       "titleBar.inactiveForeground": primer.gray[5],
-      "titleBar.inactiveBackground": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "titleBar.inactiveBackground": pick({ light: primer.gray[1], dark: "#0d1117" }),
       "titleBar.border": pick({ light: primer.gray[2], dark: primer.white }),
 
       "activityBar.foreground": workbenchForeground,
@@ -66,11 +66,11 @@ function getTheme({ style, name }) {
       "activityBar.border": pick({ light: primer.gray[2], dark: primer.white }),
 
       "sideBar.foreground": primer.gray[6],
-      "sideBar.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "sideBar.background": pick({ light: primer.gray[1], dark: "#0d1117" }),
       "sideBar.border": pick({ light: primer.gray[2], dark: primer.white }),
       "sideBarTitle.foreground": workbenchForeground,
       "sideBarSectionHeader.foreground": workbenchForeground,
-      "sideBarSectionHeader.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "sideBarSectionHeader.background": pick({ light: primer.gray[1], dark: "#0d1117" }),
       "sideBarSectionHeader.border": pick({ light: primer.gray[2], dark: primer.white }),
 
       "list.hoverForeground": workbenchForeground,
@@ -106,13 +106,13 @@ function getTheme({ style, name }) {
       "statusBar.debuggingForeground": pick({ light: primer.white, dark: primer.black }),
       "statusBarItem.prominentBackground": pick({ light: "#e8eaed", dark: "#282e34" }),
 
-      "editorGroupHeader.tabsBackground": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "editorGroupHeader.tabsBackground": pick({ light: primer.gray[1], dark: "#0d1117" }),
       "editorGroupHeader.tabsBorder": pick({ light: primer.gray[2], dark: primer.white }),
       "editorGroup.border": pick({ light: primer.gray[2], dark: primer.white }),
 
       "tab.activeForeground": workbenchForeground,
       "tab.inactiveForeground": primer.gray[5],
-      "tab.inactiveBackground": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "tab.inactiveBackground": pick({ light: primer.gray[1], dark: "#0d1117" }),
       "tab.activeBackground": pick({ light: primer.white, dark: primer.gray[0] }),
       "tab.hoverBackground": pick({ light: primer.white, dark: primer.gray[0] }),
       "tab.unfocusedHoverBackground": pick({ light: primer.white, dark: primer.gray[0] }),
@@ -128,8 +128,8 @@ function getTheme({ style, name }) {
       "breadcrumbPicker.background": pick({ light: primer.gray[0], dark: "#2b3036" }),
 
       "editor.foreground": editorForeground,
-      "editor.background": pick({ light: primer.white, dark: primer.gray[0] }),
-      "editorWidget.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "editor.background": pick({ light: primer.white, dark: "#0d1117" }),
+      "editorWidget.background": pick({ light: primer.gray[1], dark: "#0d1117" }),
       "editor.foldBackground": pick({ light: primer.gray[0], dark: "#282e33" }),
       "editor.lineHighlightBackground": pick({ light: primer.gray[1], dark: "#2b3036" }),
       "editorLineNumber.foreground": pick({ light: "#1b1f234d", dark: primer.gray[2] }),
@@ -165,7 +165,7 @@ function getTheme({ style, name }) {
       "scrollbarSlider.activeBackground": pick({ light: "#959da588", dark: "#6a737d88" }),
       "editorOverviewRuler.border": primer.white,
 
-      "panel.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
+      "panel.background": pick({ light: primer.gray[1], dark: "#0d1117" }),
       "panel.border": pick({ light: primer.gray[2], dark: primer.white }),
       "panelTitle.activeBorder": "#f9826c",
       "panelTitle.activeForeground": workbenchForeground,
@@ -188,8 +188,8 @@ function getTheme({ style, name }) {
 
       "peekViewEditor.matchHighlightBackground": pick({ dark: "#ffd33d33" }),
       "peekViewResult.matchHighlightBackground": pick({ dark: "#ffd33d33" }),
-      "peekViewEditor.background": pick({ dark: "#1f242888" }),
-      "peekViewResult.background": pick({ dark: "#1f2428" }),
+      "peekViewEditor.background": pick({ dark: "#0d111788" }),
+      "peekViewResult.background": pick({ dark: "#0d1117" }),
 
       "settings.headerForeground": workbenchForeground,
       "settings.modifiedItemIndicator": primer.blue[4],


### PR DESCRIPTION
Github has announced new dark theme. Let's sync editor background colors to be the same.

Closes #96 