### PR TITLE
Improve JavaScript/React highlighting

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -215,25 +215,47 @@ function getTheme({ theme, name }) {
           "entity.name.constant",
           "variable.other.constant",
           "variable.language",
+          "entity",
         ],
         settings: {
           foreground: themes({ light: scale.blue[6], dark: scale.blue[2], dimmed: scale.blue[2] }),
         },
       },
       {
-        scope: ["entity", "entity.name"],
+        scope: [
+          "entity.name",
+          "meta.export.default",
+          "meta.definition.variable"
+        ],
         settings: {
-          foreground: themes({ light: scale.purple[5], dark: scale.purple[2], dimmed: scale.purple[2] }),
+          foreground: themes({ light: scale.orange[6], dark: scale.orange[2], dimmed: scale.orange[2] }),
         },
       },
       {
-        scope: "variable.parameter.function",
+        scope: [
+          "variable.parameter.function",
+          "meta.jsx.children",
+          "meta.block",
+          "meta.tag.attributes",
+          "entity.name.constant",
+          "meta.object.member",
+          "meta.embedded.expression"
+        ],
         settings: {
           foreground: editorForeground,
         },
       },
       {
-        scope: "entity.name.tag",
+        "scope": "entity.name.function",
+        "settings": {
+          foreground: themes({ light: scale.purple[5], dark: scale.purple[2], dimmed: scale.purple[2] }),
+        }
+      },
+      {
+        "scope": [
+          "entity.name.tag",
+          "support.class.component"
+        ],
         settings: {
           foreground: themes({ light: scale.green[6], dark: scale.green[1], dimmed: scale.green[1] }),
         },


### PR DESCRIPTION
This improves syntax highlighting for JavaScript/React.

Before | After | github.com
--- | --- | ---
![l-before](https://user-images.githubusercontent.com/378023/103497649-85f56180-4e85-11eb-884b-d5313fb92ef5.png) | ![l-after](https://user-images.githubusercontent.com/378023/103497654-8988e880-4e85-11eb-8dc6-6e8f2f1bfd24.png) | ![l-dotcom](https://user-images.githubusercontent.com/378023/103497668-8e4d9c80-4e85-11eb-9920-61775a665b5e.png)
![d-before](https://user-images.githubusercontent.com/378023/103497673-9279ba00-4e85-11eb-9078-d3837d12c480.png) | ![d-after](https://user-images.githubusercontent.com/378023/103497677-94dc1400-4e85-11eb-8eeb-d30cb1a243c2.png) | ![d-dotcom](https://user-images.githubusercontent.com/378023/103497680-960d4100-4e85-11eb-990c-7ebd40f2c1b8.png)

