### PR TITLE
Use color.border.primary for whitespace foreground

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -142,7 +142,7 @@ function getTheme({ theme, name }) {
       "editorLineNumber.activeForeground" : color.text.primary,
       "editorIndentGuide.background"      : color.border.secondary,
       "editorIndentGuide.activeBackground": color.border.primary,
-      "editorWhitespace.foreground"       : color.border.tertiary,
+      "editorWhitespace.foreground"       : color.border.primary,
       "editorCursor.foreground"           : themes({ light: scale.blue[7], dark: scale.blue[2], dimmed: scale.blue[2] }),
 
       "editor.findMatchBackground"          : themes({ light: scale.yellow[4], dark: "#ffd33d44", dimmed: "#ffd33d44" }),


### PR DESCRIPTION
Hello,

Congrats on v2 theme I really love it :tada: 

As mentioned in [this issue](https://github.com/primer/github-vscode-theme/issues/106) whitespace foreground color is kind of intense in dark mode. 

I was wondering if you could use the color.border.primary color which is kind of softer.

Thanks

### Light comparison
__tertiary__
![light_tertiary](https://user-images.githubusercontent.com/1380039/105260077-c77c5100-5b95-11eb-84b4-98c24a7769c3.png)
__primary__
![light_primary](https://user-images.githubusercontent.com/1380039/105260071-c4816080-5b95-11eb-91bc-5dc7e1aeaff5.png)

______

### Dark comparison
__tertiary__
![dark_tertiary](https://user-images.githubusercontent.com/1380039/105260135-e7ac1000-5b95-11eb-8321-e080561222c3.png)
__primary__
![dark_primary](https://user-images.githubusercontent.com/1380039/105260130-e549b600-5b95-11eb-8cac-528a0f266a99.png)
