### PR TITLE
Fix various issues for the new dark theme

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -142,7 +142,7 @@ function getTheme({ theme, name }) {
       "editorLineNumber.activeForeground" : color.text.primary,
       "editorIndentGuide.background"      : color.border.secondary,
       "editorIndentGuide.activeBackground": color.border.primary,
-      "editorWhitespace.foreground"       : color.border.tertiary,
+      "editorWhitespace.foreground"       : themes({ light: scale.gray[3], dark: scale.gray[5], dimmed: scale.gray[5] }),
       "editorCursor.foreground"           : themes({ light: scale.blue[7], dark: scale.blue[2], dimmed: scale.blue[2] }),
 
       "editor.findMatchBackground"          : themes({ light: scale.yellow[4], dark: "#ffd33d44", dimmed: "#ffd33d44" }),

--- a/src/theme.js
+++ b/src/theme.js
@@ -85,9 +85,10 @@ function getTheme({ theme, name }) {
       "list.hoverBackground"            : themes({ light: "#ebf0f4", dark: scale.gray[8], dimmed: scale.gray[8] }),
       "list.inactiveSelectionBackground": themes({ light: "#e8eaed", dark: scale.gray[8], dimmed: scale.gray[8] }),
       "list.activeSelectionBackground"  : themes({ light: "#e2e5e9", dark: scale.gray[7], dimmed: scale.gray[7] }),
-      "list.inactiveFocusBackground"    : themes({ light: scale.blue[1], dark: scale.blue[9], dimmed: scale.blue[9] }),
-      "list.focusBackground"            : themes({ light: "#cce5ff", dark: scale.gray[8], dimmed: scale.gray[8] }),
-      "list.highlightForeground"        : themes({ light: scale.blue[5], dark: scale.blue[5], dimmed: scale.blue[5] }),
+      "list.focusForeground"            : themes({ light: "#cce5ff", dark: scale.gray[0], dimmed: scale.gray[0] }),
+      "list.focusBackground"            : themes({ light: "#cce5ff", dark: scale.gray[7], dimmed: scale.gray[7] }),
+      "list.inactiveFocusBackground"    : themes({ light: scale.blue[1], dark: scale.gray[8], dimmed: scale.gray[8] }),
+      "list.highlightForeground"        : themes({ light: scale.blue[5], dark: scale.blue[4], dimmed: scale.blue[4] }),
 
       "tree.indentGuidesStroke": color.border.secondary,
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -186,7 +186,7 @@ function getTheme({ theme, name }) {
       "gitDecoration.modifiedResourceForeground"   : color.diff.change.text,
       "gitDecoration.deletedResourceForeground"    : color.diff.deletion.text,
       "gitDecoration.untrackedResourceForeground"  : color.diff.addition.text,
-      "gitDecoration.ignoredResourceForeground"    : color.text.disabled,
+      "gitDecoration.ignoredResourceForeground"    : themes({ light: scale.gray[4], dark: color.text.disabled, dimmed: color.text.disabled }),
       "gitDecoration.conflictingResourceForeground": color.text.warning,
       "gitDecoration.submoduleResourceForeground"  : color.text.secondary,
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -85,7 +85,7 @@ function getTheme({ theme, name }) {
       "list.hoverBackground"            : themes({ light: "#ebf0f4", dark: scale.gray[8], dimmed: scale.gray[8] }),
       "list.inactiveSelectionBackground": themes({ light: "#e8eaed", dark: scale.gray[8], dimmed: scale.gray[8] }),
       "list.activeSelectionBackground"  : themes({ light: "#e2e5e9", dark: scale.gray[7], dimmed: scale.gray[7] }),
-      "list.focusForeground"            : themes({ light: "#cce5ff", dark: scale.gray[0], dimmed: scale.gray[0] }),
+      "list.focusForeground"            : themes({ light: scale.blue[9], dark: scale.gray[0], dimmed: scale.gray[0] }),
       "list.focusBackground"            : themes({ light: "#cce5ff", dark: scale.gray[7], dimmed: scale.gray[7] }),
       "list.inactiveFocusBackground"    : themes({ light: scale.blue[1], dark: scale.gray[8], dimmed: scale.gray[8] }),
       "list.highlightForeground"        : themes({ light: scale.blue[5], dark: scale.blue[4], dimmed: scale.blue[4] }),

--- a/src/theme.js
+++ b/src/theme.js
@@ -86,7 +86,8 @@ function getTheme({ theme, name }) {
       "list.inactiveSelectionBackground": themes({ light: "#e8eaed", dark: scale.gray[8], dimmed: scale.gray[8] }),
       "list.activeSelectionBackground"  : themes({ light: "#e2e5e9", dark: scale.gray[7], dimmed: scale.gray[7] }),
       "list.inactiveFocusBackground"    : themes({ light: scale.blue[1], dark: scale.blue[9], dimmed: scale.blue[9] }),
-      "list.focusBackground"            : themes({ light: "#cce5ff", dark: scale.blue[8], dimmed: scale.blue[8] }),
+      "list.focusBackground"            : themes({ light: "#cce5ff", dark: scale.gray[8], dimmed: scale.gray[8] }),
+      "list.highlightForeground"        : themes({ light: scale.blue[5], dark: scale.blue[5], dimmed: scale.blue[5] }),
 
       "tree.indentGuidesStroke": color.border.secondary,
 
@@ -102,7 +103,7 @@ function getTheme({ theme, name }) {
       "pickerGroup.border"    : themes({ light: scale.gray[2], dark: scale.gray[7], dimmed: scale.gray[7] }),
       "pickerGroup.foreground": color.text.secondary,
       "quickInput.background" : themes({ light: scale.gray[0], dark: scale.gray[9], dimmed: scale.gray[9] }),
-      "quickInput.foreground" : color.text.secondary,
+      "quickInput.foreground" : color.text.primary,
 
       "statusBar.foreground"             : color.text.secondary,
       "statusBar.background"             : color.bg.canvas,


### PR DESCRIPTION
This fixes a few issues that got reported after publishing the new dark theme:

### 1. Reduce `editorWhitespace.foreground` contrast

Before | After
--- | ---
![Screen Shot 2021-01-21 at 16 21 58](https://user-images.githubusercontent.com/378023/105317279-5eccbd00-5c05-11eb-8669-e79401838dcc.png) | ![Screen Shot 2021-01-21 at 16 22 25](https://user-images.githubusercontent.com/378023/105317286-60968080-5c05-11eb-8c34-db993ea80b5a.png)

Closes #106

### 2. Fix contrast of the quick pick items

Before | After
--- | ---
![Screen Shot 2021-01-21 at 17 44 02](https://user-images.githubusercontent.com/378023/105325743-46ae6b00-5c10-11eb-8498-938fe729e2eb.png) | ![Screen Shot 2021-01-21 at 17 42 32](https://user-images.githubusercontent.com/378023/105325630-2b436000-5c10-11eb-963a-454bd1fc1bc1.png)

Closes #109
Closes #107

### 3. [Light] Reduce contrast for ignoredResource

Before | After
--- | ---
![Screen Shot 2021-01-22 at 16 47 20](https://user-images.githubusercontent.com/378023/105462330-cea87980-5cd1-11eb-89d0-67527183f631.png) | ![Screen Shot 2021-01-22 at 16 46 52](https://user-images.githubusercontent.com/378023/105462328-cd774c80-5cd1-11eb-8f1d-ae37c27eea57.png)

Closes #115