### PR TITLE
Use primer's official colors for activity bar, tab & panel borders

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -68,7 +68,7 @@ function getTheme({ theme, name }) {
       "activityBar.background"        : color.bg.canvas,
       "activityBarBadge.foreground"   : scale.white,
       "activityBarBadge.background"   : themes({ light: scale.blue[4], dark: scale.blue[5], dimmed: scale.blue[5] }),
-      "activityBar.activeBorder"      : "#f9826c",
+      "activityBar.activeBorder"      : color.underlinenav.borderActive,
       "activityBar.border"            : color.border.primary,
 
       "sideBar.foreground"             : color.text.secondary,
@@ -128,7 +128,7 @@ function getTheme({ theme, name }) {
       "tab.unfocusedActiveBorderTop": color.border.primary,
       "tab.activeBorder"            : color.bg.canvas,
       "tab.unfocusedActiveBorder"   : color.bg.canvas,
-      "tab.activeBorderTop"         : "#f9826c",
+      "tab.activeBorderTop"         : color.underlinenav.borderActive,
 
       "breadcrumb.foreground"               : color.text.tertiary,
       "breadcrumb.focusForeground"          : color.text.primary,
@@ -175,7 +175,7 @@ function getTheme({ theme, name }) {
 
       "panel.background"             : color.bg.canvasInset,
       "panel.border"                 : color.border.primary,
-      "panelTitle.activeBorder"      : "#f9826c",
+      "panelTitle.activeBorder"      : color.underlinenav.borderActive,
       "panelTitle.activeForeground"  : color.text.primary,
       "panelTitle.inactiveForeground": color.text.tertiary,
       "panelInput.border"            : color.border.primary,


### PR DESCRIPTION
This PR implements the use of primer's 'underlinenav.borderActive' color for VSCode's activity bar, tab and panel borders. Currently, all GitHub theme's have a fixed color value of `#f9826c` for these elements, this PR change would apply the correct primer color for all themes.

- GitHub Light Default: `#f78166`
- GitHub Dark Default: `#f9826c`
- GitHub Dark Dimmed: `#f78166`