### PR TITLE
Style linkedEditing

### DIFF
--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -141,6 +141,7 @@ function getTheme({ style, name }) {
 
       "editor.findMatchBackground": pick({ light: primer.yellow[4], dark: "#ffd33d44" }),
       "editor.findMatchHighlightBackground": pick({ light: "#ffdf5d66", dark: "#ffd33d22" }),
+      "editor.linkedEditingBackground": pick({ light: "#0366d611", dark: "#3392FF22" }),
       "editor.inactiveSelectionBackground": pick({ light: "#0366d611", dark: "#3392FF22" }),
       "editor.selectionBackground": pick({ light: "#0366d625", dark: "#3392FF44" }),
       "editor.selectionHighlightBackground": pick({ light: "#34d05840", dark: "#17E5E633" }),

--- a/src/theme.js
+++ b/src/theme.js
@@ -147,6 +147,7 @@ function getTheme({ theme, name }) {
 
       "editor.findMatchBackground"          : themes({ light: scale.yellow[4], dark: "#ffd33d44", dimmed: "#ffd33d44" }),
       "editor.findMatchHighlightBackground" : themes({ light: "#ffdf5d66", dark: "#ffd33d22", dimmed: "#ffd33d22" }),
+      "editor.linkedEditingBackground"      : themes({ light: "#0366d611", dark: "#3392FF22", dimmed: "#3392FF22" }),
       "editor.inactiveSelectionBackground"  : themes({ light: "#0366d611", dark: "#3392FF22", dimmed: "#3392FF22" }),
       "editor.selectionBackground"          : themes({ light: "#0366d625", dark: "#3392FF44", dimmed: "#3392FF44" }),
       "editor.selectionHighlightBackground" : themes({ light: "#34d05840", dark: "#17E5E633", dimmed: "#17E5E633" }),


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/141.

It colors `editor.linkedEditingBackground` and overrides the default red background:

Before | After
--- | ---
![Screen Shot 2021-04-16 at 17 39 22](https://user-images.githubusercontent.com/378023/115000196-7ef6da00-9edd-11eb-9faf-5eb864535d9e.png) | ![Screen Shot 2021-04-16 at 17 39 04](https://user-images.githubusercontent.com/378023/115000189-7d2d1680-9edd-11eb-9a92-e3347be47d91.png)

It's the same color as `editor.inactiveSelectionBackground`. Also, in my case, I think the border comes from `wordHighlight`.