### PR TITLE
Use opacity for foldBackground

### DIFF
--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -130,7 +130,7 @@ function getTheme({ style, name }) {
       "editor.foreground": editorForeground,
       "editor.background": pick({ light: primer.white, dark: primer.gray[0] }),
       "editorWidget.background": pick({ light: primer.gray[1], dark: "#1f2428" }),
-      "editor.foldBackground": pick({ light: primer.gray[0], dark: "#282e33" }),
+      "editor.foldBackground": pick({ light: "#d1d5da11", dark: "#58606915" }), // needs opacity
       "editor.lineHighlightBackground": pick({ light: primer.gray[1], dark: "#2b3036" }),
       "editorLineNumber.foreground": pick({ light: "#1b1f234d", dark: primer.gray[2] }),
       "editorLineNumber.activeForeground": editorForeground,

--- a/src/theme.js
+++ b/src/theme.js
@@ -136,7 +136,7 @@ function getTheme({ theme, name }) {
       "editor.foreground"                 : color.text.primary,
       "editor.background"                 : color.bg.canvas,
       "editorWidget.background"           : color.bg.overlay,
-      "editor.foldBackground"             : color.bg.canvasInset,
+      "editor.foldBackground"             : chroma(scale.gray[4]).alpha(0.1).hex(), // needs opacity
       "editor.lineHighlightBackground"    : color.codemirror.activelineBg,
       "editorLineNumber.foreground"       : color.codemirror.linenumberText,
       "editorLineNumber.activeForeground" : color.text.primary,


### PR DESCRIPTION
This uses opacity for the `editor.foldBackground` so that selections on folded lines are still visible.

![Screen Shot 2021-04-16 at 20 57 29](https://user-images.githubusercontent.com/378023/115022172-fdf90c00-9ef7-11eb-802d-613efd718548.png)
 
Fixes https://github.com/primer/github-vscode-theme/issues/43
Fixes https://github.com/primer/github-vscode-theme/issues/53