### PR TITLE
Fix sidebar contrast

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -69,7 +69,7 @@ function getTheme({ theme, name }) {
       "activityBar.activeBorder"      : color.underlinenav.borderActive,
       "activityBar.border"            : color.border.primary,
 
-      "sideBar.foreground"             : color.text.secondary,
+      "sideBar.foreground"             : color.text.primary,
       "sideBar.background"             : color.bg.canvasInset,
       "sideBar.border"                 : color.border.primary,
       "sideBarTitle.foreground"        : color.text.primary,


### PR DESCRIPTION
This PR fixes the sidebar contrast between active and inactive list items. See screenshots below of before and after:

#### Screenshots of low contrast

| GitHub Light Default | GitHub Dark Default | GitHub Dark Dimmed |
| --------------------------- | --------------------------- | ---------------------------- |
| ![light-old](https://user-images.githubusercontent.com/28626241/115106582-88c02200-9f5d-11eb-99ed-8e8d26bdd970.png) | ![dark-old](https://user-images.githubusercontent.com/28626241/115106589-95dd1100-9f5d-11eb-9f62-97d5c059eec1.png) | ![dimmed-old](https://user-images.githubusercontent.com/28626241/115106597-9e354c00-9f5d-11eb-955b-1c1bf1fba59e.png) |

#### Screenshots after implementing fix

| GitHub Light Default | GitHub Dark Default | GitHub Dark Dimmed |
| --------------------------- | --------------------------- | ---------------------------- |
| ![light-new](https://user-images.githubusercontent.com/28626241/115106646-f2403080-9f5d-11eb-9c06-3f400800a990.png) | ![dark-new](https://user-images.githubusercontent.com/28626241/115106656-fa986b80-9f5d-11eb-9df2-c39690a95c4d.png) | ![dimmed-new](https://user-images.githubusercontent.com/28626241/115106662-01bf7980-9f5e-11eb-8b2a-dee82185e192.png) |

closes #148 #159
