### PR TITLE
Fix terminal colors (GitHub Light Default)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"version": "4.0.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@primer/primitives": "^4.2.1",
+				"@primer/primitives": "^4.2.2",
 				"chroma-js": "^2.1.0",
 				"color": "^3.1.2",
 				"nodemon": "^2.0.3"
@@ -18,9 +18,9 @@
 			}
 		},
 		"node_modules/@primer/primitives": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.2.1.tgz",
-			"integrity": "sha512-sI0Bw/PMCZ1kfPX1MRwoNYD6RWdvU0sGk9YYD8euYASwrr4E6aNH9dutMmHTRVe/N3/coBN7QUkV79GMt0UKyQ==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.2.2.tgz",
+			"integrity": "sha512-PHuDnaaYI5+SjK5RaLGXxYxgDkSqx3DJJCOxwVvrcA8pPUdfJ4ifFrZxly+NA/5DyHNVTzkjnaRa9V35ff9Lgg==",
 			"dev": true
 		},
 		"node_modules/@sindresorhus/is": {
@@ -1411,9 +1411,9 @@
 	},
 	"dependencies": {
 		"@primer/primitives": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.2.1.tgz",
-			"integrity": "sha512-sI0Bw/PMCZ1kfPX1MRwoNYD6RWdvU0sGk9YYD8euYASwrr4E6aNH9dutMmHTRVe/N3/coBN7QUkV79GMt0UKyQ==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.2.2.tgz",
+			"integrity": "sha512-PHuDnaaYI5+SjK5RaLGXxYxgDkSqx3DJJCOxwVvrcA8pPUdfJ4ifFrZxly+NA/5DyHNVTzkjnaRa9V35ff9Lgg==",
 			"dev": true
 		},
 		"@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		]
 	},
 	"devDependencies": {
-		"@primer/primitives": "^4.2.1",
+		"@primer/primitives": "^4.2.2",
 		"chroma-js": "^2.1.0",
 		"color": "^3.1.2",
 		"nodemon": "^2.0.3"


### PR DESCRIPTION
This bumps `@primer/primitives` to `4.2.2`. It includes https://github.com/primer/primitives/pull/73 and should fix the low contrast of the terminal colors in `GitHub Light Default`: 

Before | After
--- | ---
![Screen Shot 2021-04-19 at 13 58 27](https://user-images.githubusercontent.com/378023/115184673-4e02e900-a119-11eb-8289-e676c8460ab6.png) | ![Screen Shot 2021-04-19 at 13 43 14](https://user-images.githubusercontent.com/378023/115184670-4ba08f00-a119-11eb-9c77-119dd39b3b7f.png)

Fixes https://github.com/primer/github-vscode-theme/issues/157
Fixes https://github.com/primer/github-vscode-theme/issues/155