### PR TITLE
Use opacity for stackFrameHighlight

### DIFF
--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -184,8 +184,8 @@ function getTheme({ style, name }) {
       "gitDecoration.submoduleResourceForeground": primer.gray[4],
 
       "debugToolBar.background": pick({ light: primer.white, dark: "#2b3036" }),
-      "editor.stackFrameHighlightBackground": pick({ light: primer.yellow[1], dark: "#a707" }),
-      "editor.focusedStackFrameHighlightBackground": pick({ light: primer.yellow[2], dark: "#b808" }),
+      "editor.stackFrameHighlightBackground": pick({ light: "#ffd33d33", dark: "#C6902625" }), // needs opacity (yellow)
+      "editor.focusedStackFrameHighlightBackground": pick({ light: "#28a74525", dark: "#2b6a3033" }), // needs opacity (green)
 
       "peekViewEditor.matchHighlightBackground": pick({ dark: "#ffd33d33" }),
       "peekViewResult.matchHighlightBackground": pick({ dark: "#ffd33d33" }),

--- a/src/theme.js
+++ b/src/theme.js
@@ -206,8 +206,8 @@ function getTheme({ theme, name }) {
       "gitDecoration.submoduleResourceForeground"  : color.text.secondary,
 
       "debugToolBar.background"                    : color.bg.overlay,
-      "editor.stackFrameHighlightBackground"       : themes({ light: scale.yellow[1], dark: "#a707", dimmed: "#a707" }),
-      "editor.focusedStackFrameHighlightBackground": themes({ light: scale.yellow[2], dark: "#b808", dimmed: "#b808" }),
+      "editor.stackFrameHighlightBackground"       : themes({ light: "#ffd33d33", dark: "#D2992225", dimmed: "#C6902625" }), // needs opacity (yellow)
+      "editor.focusedStackFrameHighlightBackground": themes({ light: "#28a74525", dark: "#3FB95025", dimmed: "#2b6a3033" }), // needs opacity (green)
 
       "peekViewEditor.matchHighlightBackground": themes({ dark: "#ffd33d33", dimmed: "#ffd33d33" }),
       "peekViewResult.matchHighlightBackground": themes({ dark: "#ffd33d33", dimmed: "#ffd33d33" }),


### PR DESCRIPTION
So other decorations (like selections) are still visible underneath.

![image](https://user-images.githubusercontent.com/378023/115653023-5ea99e00-a369-11eb-9508-1409f2e7eadd.png)

Fixes https://github.com/primer/github-vscode-theme/issues/136.