### PR TITLE
Improve ANSI colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"version": "4.0.3",
 			"license": "MIT",
 			"devDependencies": {
-				"@primer/primitives": "^4.2.2",
+				"@primer/primitives": "^4.3.0",
 				"chroma-js": "^2.1.0",
 				"color": "^3.1.2",
 				"nodemon": "^2.0.3"
@@ -18,9 +18,9 @@
 			}
 		},
 		"node_modules/@primer/primitives": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.2.2.tgz",
-			"integrity": "sha512-PHuDnaaYI5+SjK5RaLGXxYxgDkSqx3DJJCOxwVvrcA8pPUdfJ4ifFrZxly+NA/5DyHNVTzkjnaRa9V35ff9Lgg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.3.0.tgz",
+			"integrity": "sha512-djXxll2yVTufmhnHA1H9bMT8I3S0ID6GlSewAJvKHlv80I+5AoZASVBF+WedtH/SyloLM5wyk+Tqj1ZNmy2+RQ==",
 			"dev": true
 		},
 		"node_modules/@sindresorhus/is": {
@@ -1411,9 +1411,9 @@
 	},
 	"dependencies": {
 		"@primer/primitives": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.2.2.tgz",
-			"integrity": "sha512-PHuDnaaYI5+SjK5RaLGXxYxgDkSqx3DJJCOxwVvrcA8pPUdfJ4ifFrZxly+NA/5DyHNVTzkjnaRa9V35ff9Lgg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.3.0.tgz",
+			"integrity": "sha512-djXxll2yVTufmhnHA1H9bMT8I3S0ID6GlSewAJvKHlv80I+5AoZASVBF+WedtH/SyloLM5wyk+Tqj1ZNmy2+RQ==",
 			"dev": true
 		},
 		"@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		]
 	},
 	"devDependencies": {
-		"@primer/primitives": "^4.2.2",
+		"@primer/primitives": "^4.3.0",
 		"chroma-js": "^2.1.0",
 		"color": "^3.1.2",
 		"nodemon": "^2.0.3"


### PR DESCRIPTION
This bumps `@primer/primitives` to `4.3.0`. It includes the changes of https://github.com/primer/primitives/pull/78.

Before | After
--- | ---
![Screen Shot 2021-04-22 at 19 37 00](https://user-images.githubusercontent.com/378023/115703682-62f3ac80-a3a5-11eb-8133-169392899592.png) | ![Screen Shot 2021-04-22 at 19 37 57](https://user-images.githubusercontent.com/378023/115703686-64bd7000-a3a5-11eb-9525-5c69d24a2add.png)
![Screen Shot 2021-04-22 at 19 46 50](https://user-images.githubusercontent.com/378023/115703691-65560680-a3a5-11eb-8929-6920e714128a.png) | ![Screen Shot 2021-04-22 at 19 53 09](https://user-images.githubusercontent.com/378023/115703695-65ee9d00-a3a5-11eb-97b1-0cebbd8999fc.png)
![Screen Shot 2021-04-22 at 19 55 39](https://user-images.githubusercontent.com/378023/115703697-66873380-a3a5-11eb-96a3-bb20e4574f37.png) | ![Screen Shot 2021-04-22 at 19 56 01](https://user-images.githubusercontent.com/378023/115703698-66873380-a3a5-11eb-9c39-2c64646657d7.png)