### PR TITLE
Add support for secondary button style

### DIFF
--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -33,6 +33,10 @@ function getTheme({ style, name }) {
       "button.foreground": pick({ light: primer.white, dark: primer.green[8] }),
       "button.hoverBackground": pick({ light: "#138934", dark: primer.green[3] }),
 
+      "button.secondaryBackground": pick({ light: primer.gray[2], dark: primer.gray[2]}),
+      "button.secondaryForeground": primer.black,
+      "button.secondaryHoverBackground": pick({ light: primer.gray[3], dark: primer.gray[3]}),
+
       "checkbox.background": pick({ light: primer.gray[0], dark: primer.gray[2] }),
       "checkbox.border": pick({ light: primer.gray[3], dark: primer.white }),
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -36,6 +36,10 @@ function getTheme({ theme, name }) {
       "button.background"     : color.btn.primary.bg,
       "button.foreground"     : color.btn.primary.text,
       "button.hoverBackground": color.btn.primary.hoverBg,
+      
+      "button.secondaryBackground"     : color.btn.activeBg,
+      "button.secondaryForeground"     : color.btn.text,
+      "button.secondaryHoverBackground": color.btn.hoverBg,
 
       "checkbox.background": color.bg.tertiary,
       "checkbox.border"    : color.border.primary,


### PR DESCRIPTION
This PR fixes #166 and adds styles for the secondary button style. Tried my best to map to the existing colors but VS Code does not have button border colors so tried to use `activeBg` for the buttons and `hoverBg` for the hover. Happy to adjust the PR for alternate colors.

## Default dark
![image](https://user-images.githubusercontent.com/35271042/116306594-1b30a480-a75a-11eb-8a20-0245da74ccea.png)

## Dark Dimmed
![image](https://user-images.githubusercontent.com/35271042/116306629-2aafed80-a75a-11eb-929d-a3bb47b39270.png)

## Light
![image](https://user-images.githubusercontent.com/35271042/116306851-71054c80-a75a-11eb-8076-e856fe875f18.png)

## Light Default
![image](https://user-images.githubusercontent.com/35271042/116307063-b45fbb00-a75a-11eb-8f5d-14545df3649f.png)

