### PR TITLE
Replace border.overlay with border.primary

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -41,7 +41,7 @@ function getTheme({ theme, name }) {
       "checkbox.border"    : color.border.primary,
 
       "dropdown.background"    : color.bg.overlay,
-      "dropdown.border"        : color.border.overlay,
+      "dropdown.border"        : color.border.primary,
       "dropdown.foreground"    : color.text.primary,
       "dropdown.listBackground": color.bg.overlay,
 


### PR DESCRIPTION
The `border.overlay` will be removed from https://github.com/primer/primitives/pull/82. In preparation for that change, this PR replaces `border.overlay` with `border.primary`. There should be no visual change since both variables use the same color.