### PR TITLE
feat: add underline support

### DIFF
--- a/.changeset/rare-games-sneeze.md
+++ b/.changeset/rare-games-sneeze.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": minor
+---
+
+feat: add underline support

--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -464,6 +464,12 @@ function getTheme({ style, name }) {
         },
       },
       {
+        scope: ["markup.underline"],
+        settings: {
+          fontStyle: "underline",
+        },
+      },
+      {
         scope: "markup.raw",
         settings: {
           foreground: primer.blue[6],
@@ -554,12 +560,6 @@ function getTheme({ style, name }) {
         scope: ["constant.other.reference.link", "string.other.link"],
         settings: {
           foreground: primer.blue[8],
-          fontStyle: "underline",
-        },
-      },
-      {
-        scope: ["markup.underline"],
-        settings: {
           fontStyle: "underline",
         },
       },

--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -557,6 +557,12 @@ function getTheme({ style, name }) {
           fontStyle: "underline",
         },
       },
+      {
+        scope: ["markup.underline"],
+        settings: {
+          fontStyle: "underline",
+        },
+      },
     ],
   };
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -571,6 +571,12 @@ function getTheme({ theme, name }) {
           fontStyle: "underline",
         },
       },
+      {
+        scope: ["markup.underline"],
+        settings: {
+          fontStyle: "underline",
+        },
+      },
     ],
   };
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -486,6 +486,12 @@ function getTheme({ theme, name }) {
         },
       },
       {
+        scope: ["markup.underline"],
+        settings: {
+          fontStyle: "underline",
+        },
+      },
+      {
         scope: "markup.raw",
         settings: {
           foreground: lightDark(scale.blue[6], scale.blue[2])
@@ -576,12 +582,6 @@ function getTheme({ theme, name }) {
         scope: ["constant.other.reference.link", "string.other.link"],
         settings: {
           foreground: lightDark(scale.blue[8], scale.blue[1]),
-          fontStyle: "underline",
-        },
-      },
-      {
-        scope: ["markup.underline"],
-        settings: {
           fontStyle: "underline",
         },
       },


### PR DESCRIPTION
It is very useful in Semantic highlighting.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/7829098/151142533-c91e2fec-7b72-463a-a104-e6e3a44e3ad3.png">
