### PR TITLE
Update remote statusbar item

### DIFF
--- a/.changeset/mean-geckos-shout.md
+++ b/.changeset/mean-geckos-shout.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Update remote statusbar item

--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -109,7 +109,8 @@ function getTheme({ style, name }) {
       "statusBar.debuggingBackground": auto("#f9826c"),
       "statusBar.debuggingForeground": pick({ light: primer.white, dark: primer.black }),
       "statusBarItem.prominentBackground": pick({ light: "#e8eaed", dark: "#282e34" }),
-      "statusBarItem.remoteForeground": primer.white
+      "statusBarItem.remoteForeground": primer.gray[6],
+      "statusBarItem.remoteBackground": pick({ light: primer.white, dark: primer.gray[0] }),
 
       "editorGroupHeader.tabsBackground": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "editorGroupHeader.tabsBorder": pick({ light: primer.gray[2], dark: primer.white }),

--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -109,6 +109,7 @@ function getTheme({ style, name }) {
       "statusBar.debuggingBackground": auto("#f9826c"),
       "statusBar.debuggingForeground": pick({ light: primer.white, dark: primer.black }),
       "statusBarItem.prominentBackground": pick({ light: "#e8eaed", dark: "#282e34" }),
+      "statusBarItem.remoteForeground": primer.white
 
       "editorGroupHeader.tabsBackground": pick({ light: primer.gray[1], dark: "#1f2428" }),
       "editorGroupHeader.tabsBorder": pick({ light: primer.gray[2], dark: primer.white }),

--- a/src/theme.js
+++ b/src/theme.js
@@ -132,6 +132,8 @@ function getTheme({ theme, name }) {
       "statusBar.debuggingBackground"    : color.danger.emphasis,
       "statusBar.debuggingForeground"    : color.fg.onEmphasis,
       "statusBarItem.prominentBackground": color.canvas.subtle,
+      "statusBarItem.remoteForeground"   : color.fg.muted,
+      "statusBarItem.remoteBackground"   : color.canvas.default,
 
       "editorGroupHeader.tabsBackground": color.canvas.inset,
       "editorGroupHeader.tabsBorder"    : color.border.default,


### PR DESCRIPTION
This updates the `statusBarItem.remoteForeground/Background` to match the rest of the status bar:

Before | After
--- | ---
![Screen Shot 2022-03-17 at 13 08 10](https://user-images.githubusercontent.com/378023/158735307-a2ca8f28-e116-4533-ab06-a0dcd432c4dd.png) | ![Screen Shot 2022-03-17 at 13 08 23](https://user-images.githubusercontent.com/378023/158735313-4388bf68-2199-44b8-bbee-50408aeb323a.png)

It's a combination of

- [x] https://github.com/primer/github-vscode-theme/pull/172
- [x] https://github.com/primer/github-vscode-theme/pull/237
