### PR TITLE
Add bracket pair colorization to new themes

### DIFF
--- a/.changeset/eleven-jobs-tickle.md
+++ b/.changeset/eleven-jobs-tickle.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": minor
+---
+
+Add bracket pair colorization

--- a/src/theme.js
+++ b/src/theme.js
@@ -221,11 +221,12 @@ function getTheme({ theme, name }) {
       'terminal.ansiBrightWhite': color.ansi.whiteBright,
 
       "editorBracketHighlight.foreground1": lightDark(scale.blue[5], scale.blue[2]),
-      "editorBracketHighlight.foreground2": lightDark(scale.orange[5], scale.orange[2]),
-      "editorBracketHighlight.foreground3": lightDark(scale.purple[5], scale.purple[2]),
-      "editorBracketHighlight.foreground4": lightDark(scale.blue[5], scale.blue[2]),
-      "editorBracketHighlight.foreground5": lightDark(scale.orange[5], scale.orange[2]),
+      "editorBracketHighlight.foreground2": lightDark(scale.green[5], scale.green[2]),
+      "editorBracketHighlight.foreground3": lightDark(scale.yellow[5], scale.yellow[2]),
+      "editorBracketHighlight.foreground4": lightDark(scale.red[5], scale.red[2]),
+      "editorBracketHighlight.foreground5": lightDark(scale.pink[5], scale.pink[2]),
       "editorBracketHighlight.foreground6": lightDark(scale.purple[5], scale.purple[2]),
+      "editorBracketHighlight.unexpectedBracket.foreground": color.fg.muted, // gray
 
       "gitDecoration.addedResourceForeground"      : color.success.fg,
       "gitDecoration.modifiedResourceForeground"   : color.attention.fg,

--- a/src/theme.js
+++ b/src/theme.js
@@ -220,6 +220,13 @@ function getTheme({ theme, name }) {
       'terminal.ansiBrightCyan': color.ansi.cyanBright,
       'terminal.ansiBrightWhite': color.ansi.whiteBright,
 
+      "editorBracketHighlight.foreground1": lightDark(scale.blue[5], scale.blue[2]),
+      "editorBracketHighlight.foreground2": lightDark(scale.orange[5], scale.orange[2]),
+      "editorBracketHighlight.foreground3": lightDark(scale.purple[5], scale.purple[2]),
+      "editorBracketHighlight.foreground4": lightDark(scale.blue[5], scale.blue[2]),
+      "editorBracketHighlight.foreground5": lightDark(scale.orange[5], scale.orange[2]),
+      "editorBracketHighlight.foreground6": lightDark(scale.purple[5], scale.purple[2]),
+
       "gitDecoration.addedResourceForeground"      : color.success.fg,
       "gitDecoration.modifiedResourceForeground"   : color.attention.fg,
       "gitDecoration.deletedResourceForeground"    : color.danger.fg,


### PR DESCRIPTION
This PR adds bracket pair colorization matching the active theme. The changes essentially bring to the new themes a feature already present in the [legacy](https://github.com/primer/github-vscode-theme/blob/649311a727bd8022dd8125f4de1bbdc042950d10/src/classic/theme.js#L216) ones.

Here is a screenshot of what it looks like:
<img width="926" alt="Screen Shot 2022-04-05 at 12 49 13 PM" src="https://user-images.githubusercontent.com/6913008/161820383-c5d282cf-d442-4bbb-90b1-4dcde0a370ff.png">
