### PR TITLE
Add inlay hint colors

### DIFF
--- a/.changeset/happy-cougars-promise.md
+++ b/.changeset/happy-cougars-promise.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": minor
+---
+
+Add inlay hint styles

--- a/src/theme.js
+++ b/src/theme.js
@@ -182,6 +182,13 @@ function getTheme({ theme, name }) {
       "editorBracketMatch.background"         : alpha(scale.green[3], 0.25),
       "editorBracketMatch.border"             : alpha(scale.green[3], 0.6),
 
+      "editorInlayHint.background": alpha(scale.gray[3], 0.2),
+      "editorInlayHint.foreground": color.fg.subtle,
+      "editorInlayHint.typeBackground": alpha(scale.gray[3], 0.2),
+      "editorInlayHint.typeForeground": color.fg.subtle,
+      "editorInlayHint.paramBackground": alpha(scale.gray[3], 0.2),
+      "editorInlayHint.paramForeground": color.fg.subtle,
+
       "editorGutter.modifiedBackground": color.attention.muted,
       "editorGutter.addedBackground"   : color.success.muted,
       "editorGutter.deletedBackground" : color.danger.muted,

--- a/src/theme.js
+++ b/src/theme.js
@@ -183,11 +183,11 @@ function getTheme({ theme, name }) {
       "editorBracketMatch.border"             : alpha(scale.green[3], 0.6),
 
       "editorInlayHint.background": alpha(scale.gray[3], 0.2),
-      "editorInlayHint.foreground": color.fg.subtle,
+      "editorInlayHint.foreground": color.fg.muted,
       "editorInlayHint.typeBackground": alpha(scale.gray[3], 0.2),
-      "editorInlayHint.typeForeground": color.fg.subtle,
+      "editorInlayHint.typeForeground": color.fg.muted,
       "editorInlayHint.paramBackground": alpha(scale.gray[3], 0.2),
-      "editorInlayHint.paramForeground": color.fg.subtle,
+      "editorInlayHint.paramForeground": color.fg.muted,
 
       "editorGutter.modifiedBackground": color.attention.muted,
       "editorGutter.addedBackground"   : color.success.muted,


### PR DESCRIPTION
This PR adds styles to color inlay hints. I based the style off how `inline code` looks on GitHub, using the appropriate primer colors.

### Examples

Both examples are of Rust code using the Light Default & Dark Default themes. The example code is taken from Rust By Example.

**Light Default**:
<img width="597" alt="screenshot of the light theme" src="https://user-images.githubusercontent.com/9995434/167322878-6606f814-043e-40c0-84a3-13c289aaab57.png">


**Dark Default**:
<img width="591" alt="screenshot of the dark theme" src="https://user-images.githubusercontent.com/9995434/167322952-3d044778-fc6c-4a56-af79-0cce0c1976b3.png">

