### PR TITLE
Fix icons in high contrast themes

### DIFF
--- a/.changeset/dirty-rivers-clap.md
+++ b/.changeset/dirty-rivers-clap.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Fix icons in high contrast themes

--- a/src/theme.js
+++ b/src/theme.js
@@ -50,6 +50,9 @@ function getTheme({ theme, name }) {
       "textPreformat.foreground" : color.fg.muted,
       "textSeparator.foreground" : color.border.muted,
 
+      "icon.foreground"           : color.fg.muted,
+      "keybindingLabel.foreground": color.fg.default,
+
       "button.background"     : color.btn.primary.bg,
       "button.foreground"     : color.btn.primary.text,
       "button.hoverBackground": color.btn.primary.hoverBg,


### PR DESCRIPTION
This fixes https://github.com/primer/github-vscode-theme/issues/264 by improving contrast for some icons:

Before | After
--- | ---
![Screen Shot 2022-07-12 at 13 51 46](https://user-images.githubusercontent.com/378023/178413688-db4beae3-7025-442c-8bf0-3f0d842950fb.png) | ![Screen Shot 2022-07-12 at 13 51 33](https://user-images.githubusercontent.com/378023/178413683-cd2aa878-c5af-4e96-8040-7274f266081e.png)
![Screen Shot 2022-07-12 at 13 51 59](https://user-images.githubusercontent.com/378023/178413689-78871206-fd58-4fb9-80af-85e1cbd6ebd5.png) | ![Screen Shot 2022-07-12 at 13 52 10](https://user-images.githubusercontent.com/378023/178413690-dfe1444f-37a4-4ab0-a980-bc31a74a5794.png)
