### PR TITLE
Improve diff colors

### DIFF
--- a/.changeset/blue-ads-notice.md
+++ b/.changeset/blue-ads-notice.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": minor
+---
+
+Improve diff colors

--- a/src/theme.js
+++ b/src/theme.js
@@ -189,8 +189,10 @@ function getTheme({ theme, name }) {
       "editorGutter.addedBackground"   : color.success.muted,
       "editorGutter.deletedBackground" : color.danger.muted,
 
-      "diffEditor.insertedTextBackground": color.success.subtle,
-      "diffEditor.removedTextBackground" : color.danger.subtle,
+      "diffEditor.insertedLineBackground": lightDark(alpha(scale.green[1], 0.3), alpha(scale.green[5], 0.2)),
+      "diffEditor.insertedTextBackground": lightDark(alpha(scale.green[2], 0.4), alpha(scale.green[5], 0.3)),
+      "diffEditor.removedLineBackground" : lightDark(alpha(scale.red[1], 0.3), alpha(scale.red[5], 0.2)),
+      "diffEditor.removedTextBackground" : lightDark(alpha(scale.red[2], 0.4), alpha(scale.red[5], 0.3)),
 
       "scrollbar.shadow"                  : alpha(scale.gray[5], 0.2),
       "scrollbarSlider.background"        : alpha(scale.gray[4], 0.2),


### PR DESCRIPTION
This improves the diff colors by making changed text stand out against the background. E.g. `3` changed to `8`:

Before | After
--- | ---
![Screen Shot 2022-07-12 at 15 32 52](https://user-images.githubusercontent.com/378023/178440544-fc5c7e96-1cd8-4242-9b7b-2d447c267422.png) | ![Screen Shot 2022-07-12 at 16 58 43](https://user-images.githubusercontent.com/378023/178440551-24e6a68c-f939-4dca-b3da-0c70d645210e.png)

Also the diff colors are now semi-transparent so that selection can be seen:

Before | After
--- | ---
![Screen Shot 2022-07-12 at 15 33 17](https://user-images.githubusercontent.com/378023/178440992-4f9c0052-d80b-448d-9d4d-3ca45be2d581.png) | ![Screen Shot 2022-07-12 at 16 58 59](https://user-images.githubusercontent.com/378023/178441000-4fdbc0a6-e50f-4864-8d96-a2816ef6dbc1.png)


