### PR TITLE
Increase contrast of the terminal

### DIFF
--- a/.changeset/late-chairs-impress.md
+++ b/.changeset/late-chairs-impress.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Increase contrast of the terminal

--- a/src/theme.js
+++ b/src/theme.js
@@ -213,10 +213,10 @@ function getTheme({ theme, name }) {
       "panelTitle.activeForeground"    : color.fg.default,
       "panelTitle.inactiveForeground"  : color.fg.muted,
       "panelInput.border"              : color.border.default,
-      
+
       "debugConsole.infoForeground": lightDark( scale.gray[6], scale.gray[3]),
       "debugConsole.warningForeground": lightDark( scale.yellow[6], scale.yellow[3]),
-      "debugConsole.errorForeground": lightDark( scale.red[5], scale.red[2]),      
+      "debugConsole.errorForeground": lightDark( scale.red[5], scale.red[2]),
       "debugConsole.sourceForeground": lightDark( scale.yellow[5], scale.yellow[2]),
       "debugConsoleInputIcon.foreground": lightDark( scale.purple[6], scale.purple[3]),
 
@@ -261,7 +261,7 @@ function getTheme({ theme, name }) {
       "symbolIcon.variableForeground": lightDark( scale.orange[6], scale.orange[3]),
       "symbolIcon.constantForeground": lightDark( scale.green[6], scale.green),
 
-      "terminal.foreground": color.fg.muted,
+      "terminal.foreground": color.fg.default,
       'terminal.ansiBlack': color.ansi.black,
       'terminal.ansiRed': color.ansi.red,
       'terminal.ansiGreen': color.ansi.green,


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/282 by increasing the foreground color of the terminal. It's more noticeable for dark themes.

Before | After
--- | ---
![Screen Shot 2022-07-13 at 15 29 24](https://user-images.githubusercontent.com/378023/178666326-fcf42da3-39b4-443d-90d9-b036f37a1068.png) | ![Screen Shot 2022-07-13 at 15 29 54](https://user-images.githubusercontent.com/378023/178666340-153d208f-94be-4846-8c53-d0e5701aed90.png)

