### PR TITLE
Colorize inline code blocks for the classic themes

### DIFF
--- a/.changeset/lemon-jokes-retire.md
+++ b/.changeset/lemon-jokes-retire.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Colorize inline code blocks for the classic themes

--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -473,7 +473,7 @@ function getTheme({ style, name }) {
         },
       },
       {
-        scope: "markup.raw",
+        scope: "markup.inline.raw",
         settings: {
           foreground: primer.blue[6],
         },


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/276 by making the same changes as in https://github.com/primer/github-vscode-theme/pull/193 also to the classic `GitHub Light` + `GitHub Dark` themes.

Before | After
--- | ---
![Screen Shot 2022-07-14 at 14 06 44](https://user-images.githubusercontent.com/378023/178903859-194b9024-30c3-4d5e-9edf-94fda849dac8.png) | ![Screen Shot 2022-07-14 at 14 07 15](https://user-images.githubusercontent.com/378023/178903866-da0d4b93-f9d3-4103-af46-fd71147d8e36.png)

