### PR TITLE
Improve selection in High Contrast themes

### DIFF
--- a/.changeset/rare-terms-knock.md
+++ b/.changeset/rare-terms-knock.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Improve selection in High Contrast themes

--- a/src/theme.js
+++ b/src/theme.js
@@ -22,6 +22,10 @@ function getTheme({ theme, name }) {
     return themes({ dark: color, dark_high_contrast: color, dark_colorblind: color, dark_dimmed: color })
   }
 
+  const onlyHighContrast = (color) => {
+    return themes({ light_high_contrast: color, dark_high_contrast: color })
+  }
+
   const onlyDarkHighContrast = (color) => {
     return themes({ dark_high_contrast: color })
   }
@@ -184,6 +188,10 @@ function getTheme({ theme, name }) {
       "editor.wordHighlightStrongBorder"      : alpha(color.neutral.muted, 0.6),
       "editorBracketMatch.background"         : alpha(scale.green[3], 0.25),
       "editorBracketMatch.border"             : alpha(scale.green[3], 0.6),
+      // text selection for High Contrast themes
+      "editor.selectionForeground"            : onlyHighContrast(color.fg.onEmphasis),
+      "editor.selectionBackground"            : onlyHighContrast(color.neutral.emphasisPlus),
+      "editor.inactiveSelectionBackground"    : onlyHighContrast(color.neutral.emphasis),
 
       "editorInlayHint.background": alpha(scale.gray[3], 0.2),
       "editorInlayHint.foreground": color.fg.muted,


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/271 by making sure the background in High Contrast themes has enough contrast.

Before | After
--- | ---
![Screen Shot 2022-07-14 at 14 35 34](https://user-images.githubusercontent.com/378023/178914089-2a905211-319c-43a1-8ac7-9dd28142a48c.png) | ![Screen Shot 2022-07-14 at 15 16 59](https://user-images.githubusercontent.com/378023/178914095-c5f15b38-50e0-43d0-8aae-4a305ee4a12c.png)
![Screen Shot 2022-07-14 at 15 17 59](https://user-images.githubusercontent.com/378023/178914096-46256a70-f3fb-428b-8100-6fa2eb68e90f.png) | ![Screen Shot 2022-07-14 at 15 14 34](https://user-images.githubusercontent.com/378023/178914093-673d7885-ff72-4502-9022-afbf05c92b9f.png)

