### PR TITLE
Add support for strikethrough

### DIFF
--- a/.changeset/eight-onions-grow.md
+++ b/.changeset/eight-onions-grow.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": minor
+---
+
+Add support for strikethrough

--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -473,6 +473,12 @@ function getTheme({ style, name }) {
         },
       },
       {
+        scope: ["markup.strikethrough"],
+        settings: {
+          fontStyle: "strikethrough",
+        },
+      },
+      {
         scope: "markup.inline.raw",
         settings: {
           foreground: primer.blue[6],

--- a/src/theme.js
+++ b/src/theme.js
@@ -570,6 +570,12 @@ function getTheme({ theme, name }) {
         },
       },
       {
+        scope: ["markup.strikethrough"],
+        settings: {
+          fontStyle: "strikethrough",
+        },
+      },
+      {
         scope: "markup.inline.raw",
         settings: {
           foreground: lightDark(scale.blue[6], scale.blue[2])


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/260 by adding support for ~~strikethrough~~.

Before | After
--- | ---
![Screen Shot 2022-07-14 at 16 00 45](https://user-images.githubusercontent.com/378023/178922270-74f14a52-c1f3-4733-afc5-7836404ec059.png) | ![Screen Shot 2022-07-14 at 16 03 19](https://user-images.githubusercontent.com/378023/178922279-2aeae9c7-040f-412b-b4fb-019680fd5be9.png)

