### PR TITLE
Remove `string source` scope

### DIFF
--- a/.changeset/curvy-falcons-invent.md
+++ b/.changeset/curvy-falcons-invent.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Remove `string source` scope

--- a/src/classic/theme.js
+++ b/src/classic/theme.js
@@ -380,12 +380,6 @@ function getTheme({ style, name }) {
         },
       },
       {
-        scope: "string source",
-        settings: {
-          foreground: editorForeground,
-        },
-      },
-      {
         scope: "string variable",
         settings: {
           foreground: primer.blue[6],

--- a/src/theme.js
+++ b/src/theme.js
@@ -477,12 +477,6 @@ function getTheme({ theme, name }) {
         },
       },
       {
-        scope: "string source",
-        settings: {
-          foreground: color.fg.default,
-        },
-      },
-      {
         scope: "string variable",
         settings: {
           foreground: lightDark(scale.blue[6], scale.blue[2])


### PR DESCRIPTION
This fixes https://github.com/primer/github-vscode-theme/issues/251 by removing the `string source` scope override.

Not sure why it initially was added, but it should colorize things like inline CSS in HTML.

Before | After
--- | ---
![Screen Shot 2022-07-14 at 16 35 07](https://user-images.githubusercontent.com/378023/178927778-9bea3ee2-f687-40fc-9ad7-c47295dfe693.png) | ![Screen Shot 2022-07-14 at 16 34 08](https://user-images.githubusercontent.com/378023/178927768-c475e2fb-df9b-4ac8-ae93-ca7d10398d51.png)
