### PR TITLE
Reduce contrast of line numbers

### DIFF
--- a/.changeset/unlucky-lamps-brush.md
+++ b/.changeset/unlucky-lamps-brush.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Reduce contrast for line numbers

--- a/src/theme.js
+++ b/src/theme.js
@@ -169,7 +169,7 @@ function getTheme({ theme, name }) {
       "editor.foldBackground"             : alpha(color.neutral.emphasis, 0.1),
       "editor.lineHighlightBackground"    : color.codemirror.activelineBg,
       "editor.lineHighlightBorder"        : onlyDarkHighContrast(color.accent.fg),
-      "editorLineNumber.foreground"       : color.codemirror.linenumberText,
+      "editorLineNumber.foreground"       : lightDark(scale.gray[4], scale.gray[4]),
       "editorLineNumber.activeForeground" : color.fg.default,
       "editorIndentGuide.background"      : color.border.muted,
       "editorIndentGuide.activeBackground": color.border.default,


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/249 by reducing the contrast of line numbers. It's currently hard to see which line is the active one (`53` in the example below).

Before | After
--- | ---
![Screen Shot 2022-07-14 at 17 47 02](https://user-images.githubusercontent.com/378023/178943118-27a32c5d-788d-49df-9e80-a33b8fa23fbd.png) | ![Screen Shot 2022-07-14 at 17 46 11](https://user-images.githubusercontent.com/378023/178943107-511a3b82-cbfd-4fbe-b255-139312c5dc46.png)

