### PR TITLE
Improve breakpoint icon for colorblind themes

### DIFF
--- a/.changeset/curvy-falcons-compare.md
+++ b/.changeset/curvy-falcons-compare.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Improve breakpoint icon for colorblind themes

--- a/src/theme.js
+++ b/src/theme.js
@@ -222,6 +222,8 @@ function getTheme({ theme, name }) {
       "panelTitle.inactiveForeground"  : color.fg.muted,
       "panelInput.border"              : color.border.default,
 
+      "debugIcon.breakpointForeground": color.danger.fg,
+
       "debugConsole.infoForeground": lightDark( scale.gray[6], scale.gray[3]),
       "debugConsole.warningForeground": lightDark( scale.yellow[6], scale.yellow[3]),
       "debugConsole.errorForeground": lightDark( scale.red[5], scale.red[2]),


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/245 by using `color.danger.fg`. It should have the effect that it's red in all themes, except for the color blind themes where it's "orange":

Colorblind themes | Other themes
--- | ---
<img width="83" alt="Screen Shot 2022-07-14 at 19 45 27" src="https://user-images.githubusercontent.com/378023/178966168-b97d35f3-ea89-48f9-8d42-3f5c70bc5e2f.png"> | <img width="81" alt="Screen Shot 2022-07-14 at 19 45 52" src="https://user-images.githubusercontent.com/378023/178966178-12ef091e-24ae-499d-a48a-97dfcf151ad9.png">
Orange | Red


