### PR TITLE
Reduce contrast for whitespace characters

### DIFF
--- a/.changeset/tall-suits-knock.md
+++ b/.changeset/tall-suits-knock.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Reduce contrast for whitespace characters

--- a/src/theme.js
+++ b/src/theme.js
@@ -173,7 +173,7 @@ function getTheme({ theme, name }) {
       "editorLineNumber.activeForeground" : color.fg.default,
       "editorIndentGuide.background"      : color.border.muted,
       "editorIndentGuide.activeBackground": color.border.default,
-      "editorWhitespace.foreground"       : color.fg.subtle,
+      "editorWhitespace.foreground"       : lightDark( scale.gray[3], scale.gray[5]),
       "editorCursor.foreground"           : color.accent.fg,
 
       "editor.findMatchBackground"            : color.attention.emphasis,


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/242 by reducing the contrast for whitespace characters.

Before | After
--- | ---
![Screen Shot 2022-07-15 at 11 45 29](https://user-images.githubusercontent.com/378023/179137727-377e1a12-edb9-44f2-adfa-c495bcce5c3a.png) | ![Screen Shot 2022-07-15 at 11 44 57](https://user-images.githubusercontent.com/378023/179137719-b4a8e3a6-1500-4a8e-8c55-4e0ed80c892b.png)
