### PR TITLE
Colorize JSON property-name

### DIFF
--- a/.changeset/quiet-rules-rest.md
+++ b/.changeset/quiet-rules-rest.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Colorize JSON property-name

--- a/src/theme.js
+++ b/src/theme.js
@@ -521,6 +521,12 @@ function getTheme({ theme, name }) {
         },
       },
       {
+        scope: "support.type.property-name.json",
+        settings: {
+          foreground: lightDark(scale.green[6], scale.green[1])
+        },
+      },
+      {
         scope: "meta.module-reference",
         settings: {
           foreground: lightDark(scale.blue[6], scale.blue[2])


### PR DESCRIPTION
This changes the property-name in JSON files to `green` and should make it easier to see the "value":

Before | After
--- | ---
![Screen Shot 2022-07-15 at 14 34 44](https://user-images.githubusercontent.com/378023/179159230-7ede75f0-afe6-4c8a-a5fd-eb07a0ca51ad.png) | ![Screen Shot 2022-07-15 at 14 39 24](https://user-images.githubusercontent.com/378023/179159243-76f727bc-22af-46c1-b700-11f0592de435.png)
![Screen Shot 2022-07-15 at 14 35 32](https://user-images.githubusercontent.com/378023/179159238-8aa4de9c-e6eb-4df2-b5c6-27fb74862108.png) | ![Screen Shot 2022-07-15 at 14 36 43](https://user-images.githubusercontent.com/378023/179159240-2572cfcb-e4d2-4f4e-9285-7cd2e2f55111.png)

- closes #20
- closes #69

### Reasoning

We have been holding off with this change mainly to stay close to github.com, but it now seems things changed and the property names in JSON files are now green. E.g. https://github.com/primer/github-vscode-theme/blob/main/package.json So it makes sense this theme follows up with the same change.
