### PR TITLE
Remove `punctuation.definition.string`

### DIFF
--- a/.changeset/grumpy-panthers-remember.md
+++ b/.changeset/grumpy-panthers-remember.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Remove `punctuation.definition.string`

--- a/src/theme.js
+++ b/src/theme.js
@@ -404,7 +404,6 @@ function getTheme({ theme, name }) {
       {
         scope: [
           "string",
-          "punctuation.definition.string",
           "string punctuation.section.embedded source",
         ],
         settings: {


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/133.

`punctuation.definition.string` should not be needed since it just inherits the color from `string` anyways.