### PR TITLE
Make `editorIndentGuide` semi-transparent

### DIFF
--- a/.changeset/itchy-spies-jog.md
+++ b/.changeset/itchy-spies-jog.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Make `editorIndentGuide` semi-transparent

--- a/src/theme.js
+++ b/src/theme.js
@@ -171,8 +171,8 @@ function getTheme({ theme, name }) {
       "editor.lineHighlightBorder"        : onlyDarkHighContrast(color.accent.fg),
       "editorLineNumber.foreground"       : lightDark(scale.gray[4], scale.gray[4]),
       "editorLineNumber.activeForeground" : color.fg.default,
-      "editorIndentGuide.background"      : color.border.muted,
-      "editorIndentGuide.activeBackground": color.border.default,
+      "editorIndentGuide.background"      : alpha(color.fg.default, 0.12),
+      "editorIndentGuide.activeBackground": alpha(color.fg.default, 0.24),
       "editorWhitespace.foreground"       : lightDark( scale.gray[3], scale.gray[5]),
       "editorCursor.foreground"           : color.accent.fg,
 


### PR DESCRIPTION
This closes https://github.com/primer/github-vscode-theme/issues/135 by making the `editorIndentGuide` semi-transparent. Now it doesn't cover selections anymore.

Before | After
--- | ---
![Screen Shot 2022-07-15 at 17 09 32](https://user-images.githubusercontent.com/378023/179183156-c5091e2e-456d-40e3-bb65-81bf6800f23a.png) | ![Screen Shot 2022-07-15 at 17 20 29](https://user-images.githubusercontent.com/378023/179183397-5777866b-984a-43a5-b162-5bde2bee3d2f.png)
