### PR TITLE
Add background color to editor sticky scroll

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -322,6 +322,8 @@ function getTheme({ theme, name }) {
       "settings.modifiedItemIndicator"   : color.attention.muted,
       "welcomePage.buttonBackground"     : color.btn.bg,
       "welcomePage.buttonHoverBackground": color.btn.hoverBg,
+
+      "editorStickyScroll.background": color.canvas.subtle,
     },
     semanticHighlighting: true,
     tokenColors: [


### PR DESCRIPTION
This PR adds background color to `editorStickyScroll`

Before:
<img width="551" alt="image" src="https://user-images.githubusercontent.com/871161/193949577-6f5a1a13-a447-4e14-baa5-00d8993eaf06.png">

After:
<img width="525" alt="image" src="https://user-images.githubusercontent.com/871161/193949542-1753efb4-4c95-4bd0-8783-309643be2cb9.png">
