### PR TITLE
Add better placeholder colors for semantic highlighting

### DIFF
--- a/.changeset/great-chairs-knock.md
+++ b/.changeset/great-chairs-knock.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Add better placeholder colors for semantic highlighting

--- a/src/theme.js
+++ b/src/theme.js
@@ -333,6 +333,15 @@ function getTheme({ theme, name }) {
       },
       {
         scope: [
+          "constant.other.placeholder", 
+          "constant.character"
+        ],
+        settings: {
+          foreground: lightDark(scale.red[5], scale.red[3])
+        },
+      },
+      {
+        scope: [
           "constant",
           "entity.name.constant",
           "variable.other.constant",


### PR DESCRIPTION
This helps close #326. The change affects go (golang), python, and possibly others. The changes will make variables inside of strings (placeholders) more visible. Below is a demo of that.

## Before

### Go

![image](https://user-images.githubusercontent.com/48590492/207448480-a27b274d-0919-408c-90cd-270db5abd5bc.png)

### Python

![image](https://user-images.githubusercontent.com/48590492/207448506-bcdfb87a-53e5-4a47-9511-54f875cb4488.png)

## After

### Go

![image](https://user-images.githubusercontent.com/48590492/207447993-04432094-431e-4ba7-a786-3976b048c1d7.png)

### Python

![image](https://user-images.githubusercontent.com/48590492/207448255-fb7d37c3-336e-40f3-8f55-ce44eccca2c1.png)
