### PR TITLE
Fix tab fg color for `GitHub Light High Contrast`

### DIFF
--- a/.changeset/calm-clocks-hunt.md
+++ b/.changeset/calm-clocks-hunt.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Fix tab color for `GitHub Light High Contrast`

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       },
       {
         "label": "GitHub Light High Contrast",
-        "uiTheme": "hc-black",
+        "uiTheme": "hc-light",
         "path": "./themes/light-high-contrast.json"
       },
       {


### PR DESCRIPTION
This fixes https://github.com/primer/github-vscode-theme/issues/321 by switching `uiTheme` to `hc-light` for the `GitHub Light High Contrast` theme. 

Before | After
--- | ---
![Screen Shot 2023-01-04 at 12 06 20](https://user-images.githubusercontent.com/378023/210477551-797d4fc6-7fae-4834-8f3c-86e724358a0f.png) | ![Screen Shot 2023-01-04 at 12 00 43](https://user-images.githubusercontent.com/378023/210477548-bc59ab1e-f781-44bd-9c2d-019a7cedaeab.png)
