### PR TITLE
Bump `primer/primitives` to `7.10.0`

### DIFF
--- a/.changeset/light-bottles-taste.md
+++ b/.changeset/light-bottles-taste.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Bump `primer/primitives` to `7.10.0`

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.1",
     "@changesets/cli": "^2.17.0",
-    "@primer/primitives": "7.1.1",
+    "@primer/primitives": "7.10.0",
     "chroma-js": "^2.1.2",
     "color": "^3.1.2",
     "nodemon": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,10 +273,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@primer/primitives@7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.1.1.tgz#46edb7f06fbe8809ebe2822bc692fc6c74dba98c"
-  integrity sha512-+Gwo89YK1OFi6oubTlah/zPxxzMNaMLy+inECAYI646KIFdzzhAsKWb3z5tSOu5Ff7no4isRV64rWfMSKLZclw==
+"@primer/primitives@7.10.0":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.10.0.tgz#de0d9648d484184442583564f02d6600b872fa5f"
+  integrity sha512-DdLHq21e93R9qDHyRuRpytBLY0Up9IwNWMOUgPNW6lRSng4N4+IdUlLS3Ekbasmxfs8Z8vKS8aezeYovQ5qsxQ==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"


### PR DESCRIPTION
This bumps `primer/primitives` to `7.10.0`.

There are quite a bit of changes, see under [Colors changed](https://github.com/primer/github-vscode-theme/pull/344#issuecomment-1370574837). But it should bring this theme in sync with github.com and should fix https://github.com/primer/github-vscode-theme/issues/290.

`7.1.1` | `7.10.0`
--- | ---
![Screen Shot 2023-01-04 at 15 35 43](https://user-images.githubusercontent.com/378023/210503186-c8418ee9-92f5-4881-a30c-9ca32b7eb76b.png) | ![Screen Shot 2023-01-04 at 15 42 27](https://user-images.githubusercontent.com/378023/210503188-e99186d8-5a4e-4f41-a6cc-b21ced25be3c.png)

## Approach

```
yarn add @primer/primitives@7.10.0
```
