### PR TITLE
Improve minimap slider contrast

### DIFF
--- a/.changeset/great-socks-type.md
+++ b/.changeset/great-socks-type.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Improve minimap slider contrast

--- a/src/theme.js
+++ b/src/theme.js
@@ -214,10 +214,14 @@ function getTheme({ theme, name }) {
       "diffEditor.removedTextBackground" : lightDark(alpha(scale.red[3], 0.4), alpha(scale.red[3], 0.3)),
 
       "scrollbar.shadow"                  : alpha(scale.gray[5], 0.2),
-      "scrollbarSlider.background"        : alpha(scale.gray[4], 0.2),
-      "scrollbarSlider.hoverBackground"   : alpha(scale.gray[4], 0.27),
-      "scrollbarSlider.activeBackground"  : alpha(scale.gray[4], 0.53),
+      "scrollbarSlider.background"        : lightDark(alpha(scale.gray[4], 0.2), alpha(scale.gray[3], 0.2)),
+      "scrollbarSlider.hoverBackground"   : lightDark(alpha(scale.gray[4], 0.24), alpha(scale.gray[3], 0.24)),
+      "scrollbarSlider.activeBackground"  : lightDark(alpha(scale.gray[4], 0.28), alpha(scale.gray[3], 0.28)),
       "editorOverviewRuler.border"        : lightDark(scale.white, scale.black),
+
+      "minimapSlider.background"          : lightDark(alpha(scale.gray[4], 0.2), alpha(scale.gray[3], 0.2)),
+      "minimapSlider.hoverBackground"     : lightDark(alpha(scale.gray[4], 0.24), alpha(scale.gray[3], 0.24)),
+      "minimapSlider.activeBackground"    : lightDark(alpha(scale.gray[4], 0.28), alpha(scale.gray[3], 0.28)),
 
       "panel.background"               : color.canvas.inset,
       "panel.border"                   : color.border.default,
@@ -333,7 +337,7 @@ function getTheme({ theme, name }) {
       },
       {
         scope: [
-          "constant.other.placeholder", 
+          "constant.other.placeholder",
           "constant.character"
         ],
         settings: {


### PR DESCRIPTION
This improves the slider contrast for the minimap. It also keeps it in sync with the editor scrollbars.

Closes https://github.com/primer/github-vscode-theme/issues/200

### Screenshots

Before | After
--- | ---
![Screen Shot 2023-01-05 at 12 23 15](https://user-images.githubusercontent.com/378023/210695202-13d3c354-2ff8-4f24-b5eb-020b12e48583.png) | ![Screen Shot 2023-01-05 at 12 24 55](https://user-images.githubusercontent.com/378023/210695093-933195c2-6238-474e-b5ad-bd005d07d254.png) 
![Screen Shot 2023-01-05 at 12 16 46](https://user-images.githubusercontent.com/378023/210694232-23463cca-f3f0-4a65-aa26-7563f194f6ff.png) | ![Screen Shot 2023-01-05 at 12 15 57](https://user-images.githubusercontent.com/378023/210694224-496cd853-9fd4-4e3c-841f-0383cfb1199d.png)


### Merge checklist

- [x] Added/updated colors
- [ ] Added/updated documentation/README
- [x] Tested in `GitHub Light Default` + `GitHub Dark Default` theme

Take a look at the [Contribute](https://github.com/primer/github-vscode-theme#contribute) section for more information on how test your changes locally.
