### PR TITLE
Remove underline from link text

### DIFF
--- a/.changeset/silver-fans-promise.md
+++ b/.changeset/silver-fans-promise.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Remove underline from link text

--- a/src/theme.js
+++ b/src/theme.js
@@ -333,7 +333,7 @@ function getTheme({ theme, name }) {
       },
       {
         scope: [
-          "constant.other.placeholder", 
+          "constant.other.placeholder",
           "constant.character"
         ],
         settings: {
@@ -686,7 +686,6 @@ function getTheme({ theme, name }) {
         scope: ["constant.other.reference.link", "string.other.link"],
         settings: {
           foreground: lightDark(scale.blue[8], scale.blue[1]),
-          fontStyle: "underline",
         },
       },
     ],


### PR DESCRIPTION
This removes the `underline` for the text part of links in markdown. 

```diff
  [link](https://github.com)
-  ----  ------------------
  [link](https://github.com)
+        ------------------
```

Doing so allows the link text to be _italic_ when the whole text block is italic. I think this is also better because only the URL part is actually clickable and should be underlined.

Closes https://github.com/primer/github-vscode-theme/issues/74

### Screenshots

Before | After
--- | ---
![Screen Shot 2023-01-05 at 17 45 31](https://user-images.githubusercontent.com/378023/210739034-94d3d21f-ab5f-4e8c-947c-09a9bb3b0cb7.png) | ![Screen Shot 2023-01-05 at 17 46 07](https://user-images.githubusercontent.com/378023/210739035-ca59a7e9-d7a3-450b-a821-38e4c88653f5.png)


### Merge checklist

- [ ] Added/updated colors
- [ ] Added/updated documentation/README
- [x] Tested in `GitHub Light Default` theme

Take a look at the [Contribute](https://github.com/primer/github-vscode-theme#contribute) section for more information on how test your changes locally.
