### PR TITLE
Update the color for the active header foreground 

### DIFF
--- a/.changeset/itchy-crabs-reply.md
+++ b/.changeset/itchy-crabs-reply.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Update the color for the active header foreground

--- a/src/theme.js
+++ b/src/theme.js
@@ -318,7 +318,7 @@ function getTheme({ theme, name }) {
       "peekViewEditor.background"              : onlyDark(color.neutral.subtle),
       "peekViewResult.background"              : onlyDark(scale.gray[9]),
 
-      "settings.headerForeground"        : color.fg.muted,
+      "settings.headerForeground"        : color.fg.default,
       "settings.modifiedItemIndicator"   : color.attention.muted,
       "welcomePage.buttonBackground"     : color.btn.bg,
       "welcomePage.buttonHoverBackground": color.btn.hoverBg,


### PR DESCRIPTION
Updating the `settings.headerForeground` from `fg.muted` to `fg.default` to make it more distinguishable from the rest of the options.

Closes #199 

### Screenshots
<img width="1092" alt="Screen Shot 2023-01-06 at 10 23 08 am" src="https://user-images.githubusercontent.com/1446503/210904909-f7a4aa36-d9db-4f43-a583-4cd7e8dba3be.png">



### Merge checklist

- [x] Added/updated colors
- [] Added/updated documentation/README
- [x] Tested in `GitHub Light Default` theme

Take a look at the [Contribute](https://github.com/primer/github-vscode-theme#contribute) section for more information on how test your changes locally.

