### PR TITLE
Improve color contrast for default Light + Dark themes

### DIFF
--- a/src/colors.js
+++ b/src/colors.js
@@ -10,12 +10,30 @@ function getColors(theme) {
 
   switch(theme) {
     case "light":
+
+      // Temp override until Primitives is updated
+      lightColors.success.emphasis = "#2c8747";
+      lightColors.btn.primary.bg = lightColors.success.emphasis;
+      lightColors.btn.primary.hoverBg = lightColors.scale.green[5];
+      lightColors.fg.default = "#1f2328";
+      lightColors.fg.muted = "#656d76";
+
       return lightColors;
     case "light_high_contrast":
       return lightHighContrastColors;
     case "light_colorblind":
         return lightColorblindColors;
     case "dark":
+
+      // Temp override until Primitives is updated
+      darkColors.fg.default = "#e4e8ec";
+      darkColors.fg.muted = "#7a8490";
+      darkColors.accent.fg = "#3f84e4";
+      darkColors.severe.subtle = "rgba(219, 109, 40, 0.1)";
+      darkColors.danger.subtle = "rgba(248, 81, 73, 0.1)";
+      darkColors.done.subtle = "rgba(163, 113, 247, 0.1)";
+      darkColors.sponsors.subtle = "rgba(219, 97, 162, 0.1)";
+
       return darkColors;
     case "dark_high_contrast":
       return darkHighContrastColors;


### PR DESCRIPTION
This is part of https://github.com/github/primer/issues/1648 and improves the color contrast for:

- [x] GitHub Light Default
- [x] GitHub Dark Default

### Screenshots

Before | After
--- | ---
<img width="207" alt="Screen Shot 2023-03-24 at 17 58 27" src="https://user-images.githubusercontent.com/378023/227474944-2d06d6b4-0bca-4c74-997c-32c932e9959a.png"> | <img width="204" alt="Screen Shot 2023-03-24 at 17 58 53" src="https://user-images.githubusercontent.com/378023/227474953-2156bba1-0e81-4782-9cff-268d42e440e8.png">
<img width="183" alt="Screen Shot 2023-03-24 at 18 04 35" src="https://user-images.githubusercontent.com/378023/227475238-2a675c8b-0c93-47c9-917e-104479037a32.png"> | <img width="176" alt="Screen Shot 2023-03-24 at 18 05 11" src="https://user-images.githubusercontent.com/378023/227475247-416d95ea-81a6-4095-8fe2-d6642b89b804.png">

### Merge checklist

- [x] Added/updated colors
- [ ] ~~Added/updated documentation/README~
- [x] Tested in `GitHub Light/Dark Default` theme

Take a look at the [Contribute](https://github.com/primer/github-vscode-theme#contribute) section for more information on how test your changes locally.
