### PR TITLE
Fix syntax highlight for js/ts with export default

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -360,7 +360,6 @@ function getTheme({ theme, name }) {
       {
         scope: [
           "entity.name",
-          "meta.export.default",
           "meta.definition.variable"
         ],
         settings: {


### PR DESCRIPTION
The syntax highlighting has unexpected color when using `export default` inline with class in js/ts.

Notice the curly brackets, semicolon, and parentheses all adopt the class name color. This color change also modifies other syntax. It seems as though that a possible solution might be to remove the scope `"meta.export.default"` (Dark and Light do not include this scope).

### Before
![image](https://github.com/primer/github-vscode-theme/assets/6393261/b1c0d9cc-4c23-414f-97d8-ad30188e52ad)

### After
![image](https://github.com/primer/github-vscode-theme/assets/6393261/d524e54d-6703-4a86-b5f8-f92a14116272)

### Merge checklist

- [ ] Added/updated colors
- [ ] Added/updated documentation/README
- [ ] Tested in `GitHub Light Default` theme

Take a look at the [Contribute](https://github.com/primer/github-vscode-theme#contribute) section for more information on how test your changes locally.
