### PR TITLE
Invalid "symbolIcon.constantForeground" Color

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -277,7 +277,7 @@ function getTheme({ theme, name }) {
       "symbolIcon.typeParameterForeground": lightDark( scale.blue[8], scale.blue[2]),
       "symbolIcon.unitForeground": lightDark( scale.blue[6], scale.blue[3]),
       "symbolIcon.variableForeground": lightDark( scale.orange[6], scale.orange[3]),
-      "symbolIcon.constantForeground": lightDark( scale.green[6], scale.green),
+      "symbolIcon.constantForeground": lightDark( scale.green[6], scale.green[3]),
 
       "terminal.foreground": color.fg.default,
       'terminal.ansiBlack': color.ansi.black,


### PR DESCRIPTION
### Description

The color for "symbolIcon.constantForeground" was not indexed, and as such would be ignored by VS-Code.

### Merge checklist

- [x] Added/updated colors
- [x] Tested in `GitHub Light Default` theme

