### PR TITLE
Adjust css highlight

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -382,7 +382,10 @@ function getTheme({ theme, name }) {
         },
       },
       {
-        "scope": "entity.name.function",
+        "scope": [
+          "entity.name.function",
+          "support.function",
+        ],
         "settings": {
           foreground: lightDark(scale.purple[5], scale.purple[2])
         }
@@ -690,6 +693,22 @@ function getTheme({ theme, name }) {
         scope: ["constant.other.reference.link", "string.other.link"],
         settings: {
           foreground: lightDark(scale.blue[8], scale.blue[1]),
+        },
+      },
+      {
+        scope: [
+          "support.constant.property-value.css",
+          "constant.other.color.rgb-value",
+          "support.constant.color",
+        ],
+        settings: {
+          foreground: color.fg.default,
+        },
+      },
+      {
+        scope: ["entity.name.tag.wildcard"],
+        settings: {
+          foreground: lightDark(scale.blue[6], scale.blue[2]),
         },
       },
     ],


### PR DESCRIPTION
Describe your changes here.

before:
<img width="563" alt="屏幕截图 2024-04-16 134035" src="https://github.com/primer/github-vscode-theme/assets/61723363/fd110e0d-fbbb-46b3-89e6-3dba78772ae6">
<img width="261" alt="屏幕截图 2024-04-16 134403" src="https://github.com/primer/github-vscode-theme/assets/61723363/4df7077e-a3d7-4f82-857b-892e75473df3">


after:
<img width="555" alt="屏幕截图 2024-04-16 133957" src="https://github.com/primer/github-vscode-theme/assets/61723363/9021b95b-ef0c-41ac-a9d0-2636952188c6">
<img width="269" alt="屏幕截图 2024-04-16 134326" src="https://github.com/primer/github-vscode-theme/assets/61723363/efc4629c-ad1b-43f2-bf90-b0fe8faa8a70">


### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [x] Added/updated colors
- [ ] Added/updated documentation/README
- [ ] Tested in `GitHub Light Default` theme

Take a look at the [Contribute](https://github.com/primer/github-vscode-theme#contribute) section for more information on how test your changes locally.
