### PR TITLE
Damovisa/dark high contrast inline code block

### DIFF
--- a/.changeset/orange-readers-carry.md
+++ b/.changeset/orange-readers-carry.md
@@ -1,0 +1,5 @@
+---
+"github-vscode-theme": patch
+---
+
+Fix inline code block contrast for High Contrast theme.

--- a/src/theme.js
+++ b/src/theme.js
@@ -52,7 +52,7 @@ function getTheme({ theme, name }) {
       "textBlockQuote.border"    : color.border.default,
       "textCodeBlock.background" : color.neutral.muted,
       "textPreformat.foreground" : color.fg.muted,
-      "textPreformat.background" : color.bg.muted,
+      "textPreformat.background" : color.neutral.muted,
       "textSeparator.foreground" : color.border.muted,
 
       "icon.foreground"           : color.fg.muted,

--- a/src/theme.js
+++ b/src/theme.js
@@ -52,6 +52,7 @@ function getTheme({ theme, name }) {
       "textBlockQuote.border"    : color.border.default,
       "textCodeBlock.background" : color.neutral.muted,
       "textPreformat.foreground" : color.fg.muted,
+      "textPreformat.background" : color.bg.muted,
       "textSeparator.foreground" : color.border.muted,
 
       "icon.foreground"           : color.fg.muted,


### PR DESCRIPTION
Describe your changes here.

Inline highlighted text in the Copilot Chat response was unreadable in the GitHub Dark High Contrast theme. This PR adds a missing background color for the `textPreformat.background` variable.

Closes #380 

### Screenshots

Before:
![image](https://github.com/user-attachments/assets/5356cfa0-8b71-4b36-b526-0df9eb325a16)

After:
![image](https://github.com/user-attachments/assets/8e6ea74d-8ead-4693-8641-ad3c8bdb9900)

### Merge checklist

- [x] Added/updated colors
- [ ] Added/updated documentation/README
- [x] Tested in `GitHub Light Default` theme

Take a look at the [Contribute](https://github.com/primer/github-vscode-theme#contribute) section for more information on how test your changes locally.
